### PR TITLE
[Draft] Extract Merkle tree logic from StateTree

### DIFF
--- a/models/state.go
+++ b/models/state.go
@@ -25,6 +25,18 @@ type StateLeaf struct {
 	UserState
 }
 
+func (s *StateNode) Path() *MerklePath {
+	return &s.MerklePath
+}
+
+func (s *StateNode) Hash() *common.Hash {
+	return &s.DataHash
+}
+
+func (s *StateLeaf) Index() uint32 {
+	return s.StateID
+}
+
 type StateUpdate struct {
 	ID            uint64 `badgerhold:"key"`
 	CurrentRoot   common.Hash

--- a/storage/state_tree_2.go
+++ b/storage/state_tree_2.go
@@ -1,0 +1,46 @@
+package storage
+
+import (
+	"github.com/Worldcoin/hubble-commander/models"
+	"github.com/Worldcoin/hubble-commander/utils/merkletree"
+)
+
+type StateTree2 struct {
+	StateTree
+	impl merkletree.StoredMerkleTree
+}
+
+func (s *StateTree2) Set(index uint32, state *models.UserState) (models.Witness, error) {
+	// TODO start DB transaction
+
+	prevLeaf, err := s.Leaf(index)
+	if err != nil {
+		return nil, err
+	}
+
+	prevRoot, err := s.Root()
+	if err != nil {
+		return nil, err
+	}
+
+	currentLeaf, err := NewStateLeaf(index, state)
+	if err != nil {
+		return nil, err
+	}
+
+	currentRoot, witness, err := s.impl.Set(index, currentLeaf)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.storage.AddStateUpdate(&models.StateUpdate{
+		CurrentRoot:   *currentRoot,
+		PrevRoot:      *prevRoot,
+		PrevStateLeaf: *prevLeaf,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return witness, nil
+}

--- a/storage/state_tree_storage.go
+++ b/storage/state_tree_storage.go
@@ -1,0 +1,24 @@
+package storage
+
+import (
+	"github.com/Worldcoin/hubble-commander/models"
+	"github.com/Worldcoin/hubble-commander/utils/merkletree"
+)
+
+type StateTreeStorage struct {
+	storage Storage
+}
+
+func (s *StateTreeStorage) UpsertTreeLeaf(leaf merkletree.TreeLeaf) error {
+	stateLeaf := leaf.(*models.StateLeaf)
+	return s.storage.UpsertStateLeaf(stateLeaf)
+}
+
+func (s *StateTreeStorage) UpsertTreeNode(node merkletree.TreeNode) error {
+	stateNode := node.(*models.StateNode)
+	return s.storage.UpsertStateNode(stateNode)
+}
+
+func (s *StateTreeStorage) GetTreeNode(path *models.MerklePath) (merkletree.TreeNode, error) {
+	return s.storage.GetStateNodeByPath(path)
+}

--- a/utils/merkletree/stored_merkle_tree.go
+++ b/utils/merkletree/stored_merkle_tree.go
@@ -1,0 +1,30 @@
+package merkletree
+
+import (
+	"github.com/Worldcoin/hubble-commander/models"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+type TreeLeaf interface {
+	Index() uint32
+}
+
+type TreeNode interface {
+	Path() *models.MerklePath
+	Hash() *common.Hash
+}
+
+type MerkleTreeStorage interface {
+	UpsertTreeLeaf(leaf TreeLeaf) error
+	UpsertTreeNode(node TreeNode) error
+	GetTreeNode(path *models.MerklePath) (TreeNode, error)
+}
+
+type StoredMerkleTree struct {
+	storage MerkleTreeStorage
+}
+
+func (t *StoredMerkleTree) Set(index uint32, leaf TreeLeaf) (*common.Hash, models.Witness, error) {
+	// TODO possibly start a DB tx (just in case caller hasn't done it already)
+	panic("not implemented")
+}


### PR DESCRIPTION
This is just a draft of implementation of `StoredMerkleTree`. The idea is to extract the Merkle tree logic from `StateTree` and reuse it when developing `AccountTree`. This PR shows a first step towards this goal. `Set` operations were "extracted" to `StoredMerkleTree` and the rest of the logic specific to the State tree (i.e. storing the state update) remained in the `StateTree.Set` method. 

Similarly, in `AccountTree` we'll have two methods for inserting leaves: `InsertSingle`, `InsertBatch` and some specific logic. `InsertSingle` method will call `Set` to add a leaf in the left subtree and `InsertBatch` will call `Set` with an increased index to add a leaf in the right subtree.