### PR TITLE
Update release CI

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-name: E2E Test
+name: Release
 on:
   release:
     types: [created]


### PR DESCRIPTION
This PR introduces two changes to Release CI:

1. Stop deploying commander to AWS machines and cluster on new release
2. Change tagging strategy - set `stable` tag on the built image only if the version does not contain `rc` substring
  For example: 
    - `v0.5.0` -> tag image with `v0.5.0` and `stable`
    - `v0.5.0-rc1` -> tag image with `v0.5.0-rc1` 