### PR TITLE
Fix Makefile benchmark targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -65,10 +65,10 @@ bench-e2e-locally: clean-testcache
 	HUBBLE_E2E=in-process go test -v -tags e2e -run=^$(TEST)$$ ./e2e/bench
 
 bench-creation-profile: clean-testcache
-	HUBBLE_E2E=in-process go test -cpuprofile creation.prof -v -tags e2e -run TestBenchmarkSuite/TestBenchMixedCommander ./e2e/bench
+	HUBBLE_E2E=in-process go test -cpuprofile creation.prof -v -tags e2e -run BenchmarkTransactionsSuite/TestBenchMixedCommander ./e2e/bench
 
 bench-sync-profile: clean-testcache
-	HUBBLE_E2E=in-process go test -cpuprofile sync.prof -v -tags e2e -run TestBenchmarkSuite/TestBenchSyncCommander ./e2e/bench
+	HUBBLE_E2E=in-process go test -cpuprofile sync.prof -v -tags e2e -run BenchmarkTransactionsSuite/TestBenchSyncCommander ./e2e/bench
 
 bench-e2e-ci-part-1: clean-testcache
 	HUBBLE_E2E=in-process go test -v -tags e2e -run "BenchmarkTransactionsSuite/(?:TestBenchTransfersCommander|TestBenchCreate2TransfersCommander)" ./e2e/bench


### PR DESCRIPTION
`bench-creation-profile` and `bench-sync-profile` referenced tests which
were moved in [1] but Makefile was not updated. These targets now
point where they should.

[1] https://github.com/worldcoin/hubble-commander/commit/6ce06d60