### PR TITLE
Drop Some Duplicated Code

### DIFF
--- a/api/get_commitment_proof_test.go
+++ b/api/get_commitment_proof_test.go
@@ -88,7 +88,7 @@ func (s *GetCommitmentProofTestSuite) TestGetCommitmentProof_TransferType() {
 
 	transfer := testutils.MakeTransfer(1, 2, 0, 50)
 	transfer.CommitmentID = &s.commitment.ID
-	err = s.storage.AddTransfer(&transfer)
+	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	tree, err := merkletree.NewMerkleTree([]common.Hash{s.commitment.LeafHash()})
@@ -132,7 +132,7 @@ func (s *GetCommitmentProofTestSuite) TestGetCommitmentProof_Create2TransferType
 
 	transfer := testutils.MakeCreate2Transfer(1, ref.Uint32(2), 0, 50, &models.PublicKey{2, 3, 4})
 	transfer.CommitmentID = &s.commitment.ID
-	err = s.storage.AddCreate2Transfer(&transfer)
+	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	tree, err := merkletree.NewMerkleTree([]common.Hash{s.commitment.LeafHash()})
@@ -176,7 +176,7 @@ func (s *GetCommitmentProofTestSuite) TestGetCommitmentProof_MassMigrationType()
 
 	massMigration := testutils.MakeMassMigration(1, 2, 0, 50)
 	massMigration.CommitmentID = &s.commitment.ID
-	err = s.storage.AddMassMigration(&massMigration)
+	err = s.storage.AddTransaction(&massMigration)
 	s.NoError(err)
 
 	tree, err := merkletree.NewMerkleTree([]common.Hash{s.commitment.LeafHash()})
@@ -222,7 +222,7 @@ func (s *GetCommitmentProofTestSuite) TestGetCommitmentProof_PendingBatch() {
 
 	transfer := testutils.MakeTransfer(1, 2, 0, 50)
 	transfer.CommitmentID = &s.commitment.ID
-	err = s.storage.AddTransfer(&transfer)
+	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	commitmentProof, err := s.api.GetCommitmentProof(s.commitment.ID)

--- a/api/get_commitment_test.go
+++ b/api/get_commitment_test.go
@@ -80,7 +80,7 @@ func (s *GetCommitmentTestSuite) TestGetCommitment_TransferType() {
 		},
 		ToStateID: 2,
 	}
-	err = s.storage.AddTransfer(&transfer)
+	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	expectedCommitment := &dto.Commitment{
@@ -129,7 +129,7 @@ func (s *GetCommitmentTestSuite) TestGetCommitment_Create2TransferType() {
 		ToStateID:   ref.Uint32(2),
 		ToPublicKey: models.PublicKey{2, 3, 4},
 	}
-	err = s.storage.AddCreate2Transfer(&transfer)
+	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	expectedCommitment := &dto.Commitment{
@@ -178,7 +178,7 @@ func (s *GetCommitmentTestSuite) TestGetCommitment_MassMigrationType() {
 		},
 		SpokeID: 2,
 	}
-	err = s.storage.AddMassMigration(&massMigration)
+	err = s.storage.AddTransaction(&massMigration)
 	s.NoError(err)
 
 	expectedCommitment := &dto.Commitment{
@@ -228,7 +228,7 @@ func (s *GetCommitmentTestSuite) TestGetCommitment_PendingBatch() {
 		},
 		ToStateID: 2,
 	}
-	err = s.storage.AddTransfer(&transfer)
+	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	commitment, err := s.api.GetCommitment(commitment.ID)

--- a/api/get_network_info_test.go
+++ b/api/get_network_info_test.go
@@ -109,7 +109,7 @@ func (s *NetworkInfoTestSuite) TestGetNetworkInfo() {
 	commitmentInBatch.ID.BatchID = batches[0].ID
 	err = s.api.storage.AddTxCommitment(&commitmentInBatch)
 	s.NoError(err)
-	err = s.api.storage.AddTransfer(&models.Transfer{
+	err = s.api.storage.AddTransaction(&models.Transfer{
 		TransactionBase: models.TransactionBase{
 			Hash:         common.Hash{1, 2, 3},
 			TxType:       txtype.Transfer,

--- a/api/handle_create2transfer.go
+++ b/api/handle_create2transfer.go
@@ -32,7 +32,7 @@ func (a *API) handleCreate2Transfer(create2TransferDTO dto.Create2Transfer) (*co
 
 	defer logReceivedTransaction(*hash, create2TransferDTO)
 
-	err = a.storage.AddCreate2Transfer(create2Transfer)
+	err = a.storage.AddTransaction(create2Transfer)
 	if errors.Is(err, bh.ErrKeyExists) {
 		return a.updateDuplicatedTransaction(create2Transfer)
 	}

--- a/api/handle_mass_migration.go
+++ b/api/handle_mass_migration.go
@@ -32,7 +32,7 @@ func (a *API) handleMassMigration(massMigrationDTO dto.MassMigration) (*common.H
 
 	defer logReceivedTransaction(*hash, massMigrationDTO)
 
-	err = a.storage.AddMassMigration(massMigration)
+	err = a.storage.AddTransaction(massMigration)
 	if errors.Is(err, bh.ErrKeyExists) {
 		return a.updateDuplicatedTransaction(massMigration)
 	}

--- a/api/handle_transfer.go
+++ b/api/handle_transfer.go
@@ -32,7 +32,7 @@ func (a *API) handleTransfer(transferDTO dto.Transfer) (*common.Hash, error) {
 
 	defer logReceivedTransaction(*hash, transferDTO)
 
-	err = a.storage.AddTransfer(transfer)
+	err = a.storage.AddTransaction(transfer)
 	if errors.Is(err, bh.ErrKeyExists) {
 		return a.updateDuplicatedTransaction(transfer)
 	}

--- a/commander/executor/create_commitments_test.go
+++ b/commander/executor/create_commitments_test.go
@@ -247,7 +247,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_SkipsNonceTooHighTx()
 	nonceTooHighTx.Nonce = models.MakeUint256(21)
 
 	s.addTransfers(validTxs)
-	err := s.storage.AddTransfer(nonceTooHighTx)
+	err := s.storage.AddTransaction(nonceTooHighTx)
 	s.NoError(err)
 
 	batchData, err := s.txsCtx.CreateCommitments()
@@ -394,13 +394,13 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_SupportsTransactionRe
 
 	transfer := testutils.MakeTransfer(1, 2, 0, 100)
 	transfer.Hash = common.BytesToHash([]byte{1})
-	err := s.storage.AddTransfer(&transfer)
+	err := s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	higherFeeTransfer := transfer
 	higherFeeTransfer.Hash = common.BytesToHash([]byte{2})
 	higherFeeTransfer.Fee = *transfer.Fee.MulN(2)
-	err = s.storage.AddTransfer(&higherFeeTransfer)
+	err = s.storage.AddTransaction(&higherFeeTransfer)
 	s.NoError(err)
 
 	s.Less(transfer.Hash.String(), higherFeeTransfer.Hash.String())
@@ -434,7 +434,7 @@ func (s *CreateCommitmentsTestSuite) hashSignAndAddTransfer(wallet *bls.Wallet, 
 	s.NoError(err)
 	transfer.Signature = *signature.ModelsSignature()
 
-	err = s.storage.AddTransfer(transfer)
+	err = s.storage.AddTransaction(transfer)
 	s.NoError(err)
 }
 

--- a/commander/executor/execute_c2ts_test.go
+++ b/commander/executor/execute_c2ts_test.go
@@ -96,7 +96,7 @@ func (s *ExecuteCreate2TransfersTestSuite) TestExecuteTxs_SavesTxErrors() {
 	generatedTransfers = append(generatedTransfers, testutils.GenerateInvalidCreate2Transfers(2)...)
 
 	for i := range generatedTransfers {
-		err := s.storage.AddCreate2Transfer(&generatedTransfers[i])
+		err := s.storage.AddTransaction(&generatedTransfers[i])
 		s.NoError(err)
 	}
 

--- a/commander/executor/execute_transfers_test.go
+++ b/commander/executor/execute_transfers_test.go
@@ -114,7 +114,7 @@ func (s *ExecuteTransfersTestSuite) TestExecuteTxs_SavesTxErrors() {
 	generatedTransfers := testutils.GenerateValidTransfers(3)
 	generatedTransfers = append(generatedTransfers, testutils.GenerateInvalidTransfers(2)...)
 
-	err := s.storage.BatchAddTransfer(generatedTransfers)
+	err := s.storage.BatchAddTransaction(generatedTransfers)
 	s.NoError(err)
 
 	result, err := s.txsCtx.ExecuteTxs(generatedTransfers, s.feeReceiver)

--- a/commander/executor/revert_batches_test.go
+++ b/commander/executor/revert_batches_test.go
@@ -123,7 +123,7 @@ func (s *RevertBatchesTestSuite) TestRevertBatches_AddsPendingDepositSubtree() {
 }
 
 func (s *RevertBatchesTestSuite) addTxBatch(tx *models.Transfer) *models.Batch {
-	err := s.txsCtx.storage.AddTransfer(tx)
+	err := s.txsCtx.storage.AddTransaction(tx)
 	s.NoError(err)
 
 	pendingBatch, err := s.txsCtx.NewPendingBatch(s.txsCtx.BatchType)

--- a/commander/mm_batches_test.go
+++ b/commander/mm_batches_test.go
@@ -58,7 +58,7 @@ func (s *MMBatchesTestSuite) TearDownTest() {
 
 func (s *MMBatchesTestSuite) TestSyncRemoteBatch_SyncsBatch() {
 	tx := testutils.MakeMassMigration(0, 1, 0, 100)
-	err := s.storage.AddMassMigration(&tx)
+	err := s.storage.AddTransaction(&tx)
 	s.NoError(err)
 
 	s.submitBatch(s.storage.Storage)
@@ -137,7 +137,7 @@ func (s *MMBatchesTestSuite) submitInvalidBatch(tx *models.MassMigration, modifi
 	txController, txStorage := s.storage.BeginTransaction(st.TxOptions{})
 	defer txController.Rollback(nil)
 
-	err := txStorage.AddMassMigration(tx)
+	err := txStorage.AddTransaction(tx)
 	s.NoError(err)
 
 	executionCtx := executor.NewTestExecutionContext(txStorage, s.client.Client, s.cfg.Rollup)

--- a/commander/new_block_test.go
+++ b/commander/new_block_test.go
@@ -162,7 +162,7 @@ func (s *NewBlockLoopTestSuite) registerAccounts(accounts []models.AccountLeaf) 
 
 func (s *NewBlockLoopTestSuite) submitTransferBatchInTransaction(tx *models.Transfer) {
 	s.runInTransaction(func(txStorage *st.Storage, txsCtx *executor.TxsContext) {
-		err := txStorage.AddTransfer(tx)
+		err := txStorage.AddTransaction(tx)
 		s.NoError(err)
 
 		batchData, err := txsCtx.CreateCommitments()

--- a/commander/rollup_test.go
+++ b/commander/rollup_test.go
@@ -72,9 +72,9 @@ func (s *RollupTestSuite) TestRollupLoopIteration_RollbacksStateOnRollupErrorBut
 	invalidTransfer := testutils.MakeTransfer(0, 1, 0, 100)
 	s.setTxHashAndSign(&s.wallets[1], &invalidTransfer)
 
-	err := s.testStorage.AddTransfer(&validTransfer)
+	err := s.testStorage.AddTransaction(&validTransfer)
 	s.NoError(err)
-	err = s.testStorage.AddTransfer(&invalidTransfer)
+	err = s.testStorage.AddTransaction(&invalidTransfer)
 	s.NoError(err)
 
 	preStateRoot, err := s.testStorage.StateTree.Root()
@@ -100,7 +100,7 @@ func (s *RollupTestSuite) TestRollupLoopIteration_RerunIterationWhenNotEnoughDep
 	validTransfer := testutils.MakeTransfer(1, 2, 0, 100)
 	s.setTxHashAndSign(&s.wallets[0], &validTransfer)
 
-	err := s.testStorage.AddTransfer(&validTransfer)
+	err := s.testStorage.AddTransaction(&validTransfer)
 	s.NoError(err)
 
 	currentBatchType := batchtype.Deposit

--- a/commander/syncer/txs_sync_transfer_batch_test.go
+++ b/commander/syncer/txs_sync_transfer_batch_test.go
@@ -48,7 +48,7 @@ func (s *SyncTransferBatchTestSuite) TestSyncBatch_TwoBatches() {
 	}
 	s.setTxHashAndSign(txs...)
 	for i := range txs {
-		err := s.storage.AddTransfer(txs[i])
+		err := s.storage.AddTransaction(txs[i])
 		s.NoError(err)
 	}
 

--- a/commander/txs_batches_test.go
+++ b/commander/txs_batches_test.go
@@ -483,7 +483,7 @@ func (s *TxsBatchesTestSuite) syncAllBlocks() {
 }
 
 func (s *TxsBatchesTestSuite) createTransferBatchLocally(tx *models.Transfer) *models.Batch {
-	err := s.cmd.storage.AddTransfer(tx)
+	err := s.cmd.storage.AddTransaction(tx)
 	s.NoError(err)
 
 	pendingBatch, err := s.txsCtx.NewPendingBatch(batchtype.Transfer)

--- a/models/generic_transaction.go
+++ b/models/generic_transaction.go
@@ -100,6 +100,10 @@ func (t TransferArray) ToMassMigrationArray() MassMigrationArray {
 
 type Create2TransferArray []Create2Transfer
 
+func MakeCreate2TransferArray(txns ...Create2Transfer) Create2TransferArray {
+	return txns
+}
+
 func (t Create2TransferArray) Len() int {
 	return len(t)
 }
@@ -141,6 +145,10 @@ func (t Create2TransferArray) ToMassMigrationArray() MassMigrationArray {
 }
 
 type MassMigrationArray []MassMigration
+
+func MakeMassMigrationArray(txns ...MassMigration) MassMigrationArray {
+	return txns
+}
 
 func (m MassMigrationArray) Len() int {
 	return len(m)

--- a/models/stored/tx_receipt.go
+++ b/models/stored/tx_receipt.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/Worldcoin/hubble-commander/models"
+	"github.com/Worldcoin/hubble-commander/models/enums/txtype"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	bh "github.com/timshannon/badgerhold/v4"
@@ -22,6 +23,18 @@ type TxReceipt struct {
 	CommitmentID *models.CommitmentID
 	ToStateID    *uint32 // specified for C2Ts, nil for Transfers and MassMigrations
 	ErrorMessage *string
+}
+
+func NewTxReceipt(tx models.GenericTransaction) *TxReceipt {
+	switch tx.Type() {
+	case txtype.Transfer:
+		return NewTxReceiptFromTransfer(tx.ToTransfer())
+	case txtype.Create2Transfer:
+		return NewTxReceiptFromCreate2Transfer(tx.ToCreate2Transfer())
+	case txtype.MassMigration:
+		return NewTxReceiptFromMassMigration(tx.ToMassMigration())
+	}
+	return nil
 }
 
 func NewTxReceiptFromTransfer(t *models.Transfer) *TxReceipt {

--- a/storage/create2transfer.go
+++ b/storage/create2transfer.go
@@ -10,32 +10,13 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (s *TransactionStorage) AddCreate2Transfer(t *models.Create2Transfer) error {
-	return s.executeInTransaction(TxOptions{}, func(txStorage *TransactionStorage) error {
-		if t.CommitmentID != nil || t.ErrorMessage != nil || t.ToStateID != nil {
-			err := txStorage.addStoredTxReceipt(stored.NewTxReceiptFromCreate2Transfer(t))
-			if err != nil {
-				return err
-			}
-		}
-		return txStorage.addStoredTx(stored.NewTxFromCreate2Transfer(t))
-	})
+func (s *TransactionStorage) AddCreate2Transfer(tx *models.Create2Transfer) error {
+	// TODO: This used to check for ToStateID, was that important?
+	return s.AddTransaction(tx)
 }
 
 func (s *TransactionStorage) BatchAddCreate2Transfer(txs []models.Create2Transfer) error {
-	if len(txs) < 1 {
-		return errors.WithStack(ErrNoRowsAffected)
-	}
-
-	return s.executeInTransaction(TxOptions{}, func(txStorage *TransactionStorage) error {
-		for i := range txs {
-			err := txStorage.AddCreate2Transfer(&txs[i])
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+	return s.BatchAddTransaction(models.MakeCreate2TransferArray(txs...))
 }
 
 func (s *TransactionStorage) GetCreate2Transfer(hash common.Hash) (*models.Create2Transfer, error) {

--- a/storage/create2transfer.go
+++ b/storage/create2transfer.go
@@ -10,11 +10,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (s *TransactionStorage) AddCreate2Transfer(tx *models.Create2Transfer) error {
-	// TODO: This used to check for ToStateID, was that important?
-	return s.AddTransaction(tx)
-}
-
 func (s *TransactionStorage) BatchAddCreate2Transfer(txs []models.Create2Transfer) error {
 	return s.BatchAddTransaction(models.MakeCreate2TransferArray(txs...))
 }

--- a/storage/create2transfer_test.go
+++ b/storage/create2transfer_test.go
@@ -53,7 +53,7 @@ func (s *Create2TransferTestSuite) TearDownTest() {
 }
 
 func (s *Create2TransferTestSuite) TestAddCreate2Transfer_AddAndRetrieve() {
-	err := s.storage.AddCreate2Transfer(&create2Transfer)
+	err := s.storage.AddTransaction(&create2Transfer)
 	s.NoError(err)
 
 	expected := create2Transfer
@@ -64,7 +64,7 @@ func (s *Create2TransferTestSuite) TestAddCreate2Transfer_AddAndRetrieve() {
 }
 
 func (s *Create2TransferTestSuite) TestGetCreate2Transfer_DifferentTxType() {
-	err := s.storage.AddTransfer(&transfer)
+	err := s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	_, err = s.storage.GetCreate2Transfer(transfer.Hash)
@@ -81,7 +81,7 @@ func (s *Create2TransferTestSuite) TestMarkCreate2TransfersAsIncluded() {
 	for i := 0; i < len(txs); i++ {
 		txs[i] = create2Transfer
 		txs[i].Hash = utils.RandomHash()
-		err := s.storage.AddCreate2Transfer(&txs[i])
+		err := s.storage.AddTransaction(&txs[i])
 		s.NoError(err)
 
 		txs[i].ToStateID = ref.Uint32(uint32(i))
@@ -163,7 +163,7 @@ func (s *Create2TransferTestSuite) TestGetPendingCreate2Transfers() {
 func (s *Create2TransferTestSuite) TestGetCreate2TransfersByCommitmentID() {
 	transfer1 := create2Transfer
 	transfer1.CommitmentID = &txCommitment.ID
-	err := s.storage.AddCreate2Transfer(&transfer1)
+	err := s.storage.AddTransaction(&transfer1)
 	s.NoError(err)
 
 	otherCommitmentID := txCommitment.ID
@@ -171,7 +171,7 @@ func (s *Create2TransferTestSuite) TestGetCreate2TransfersByCommitmentID() {
 	transfer2 := create2Transfer
 	transfer2.Hash = utils.RandomHash()
 	transfer2.CommitmentID = &otherCommitmentID
-	err = s.storage.AddCreate2Transfer(&transfer2)
+	err = s.storage.AddTransaction(&transfer2)
 	s.NoError(err)
 
 	transfers, err := s.storage.GetCreate2TransfersByCommitmentID(txCommitment.ID)
@@ -189,7 +189,7 @@ func (s *Create2TransferTestSuite) TestGetCreate2TransfersByCommitmentID_NoTrans
 func (s *Create2TransferTestSuite) TestGetCreate2TransfersByCommitmentID_NoCreate2TransfersButSomeTransfers() {
 	transferCopy := transfer
 	transferCopy.CommitmentID = &txCommitment.ID
-	err := s.storage.AddTransfer(&transferCopy)
+	err := s.storage.AddTransaction(&transferCopy)
 	s.NoError(err)
 
 	transfers, err := s.storage.GetCreate2TransfersByCommitmentID(txCommitment.ID)

--- a/storage/mass_migration.go
+++ b/storage/mass_migration.go
@@ -10,32 +10,12 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (s *TransactionStorage) AddMassMigration(m *models.MassMigration) error {
-	return s.executeInTransaction(TxOptions{}, func(txStorage *TransactionStorage) error {
-		if m.CommitmentID != nil || m.ErrorMessage != nil {
-			err := txStorage.addStoredTxReceipt(stored.NewTxReceiptFromMassMigration(m))
-			if err != nil {
-				return err
-			}
-		}
-		return txStorage.addStoredTx(stored.NewTxFromMassMigration(m))
-	})
+func (s *TransactionStorage) AddMassMigration(tx *models.MassMigration) error {
+	return s.AddTransaction(tx)
 }
 
 func (s *TransactionStorage) BatchAddMassMigration(txs []models.MassMigration) error {
-	if len(txs) < 1 {
-		return errors.WithStack(ErrNoRowsAffected)
-	}
-
-	return s.executeInTransaction(TxOptions{}, func(txStorage *TransactionStorage) error {
-		for i := range txs {
-			err := txStorage.AddMassMigration(&txs[i])
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+	return s.BatchAddTransaction(models.MakeMassMigrationArray(txs...))
 }
 
 func (s *TransactionStorage) GetMassMigration(hash common.Hash) (*models.MassMigration, error) {

--- a/storage/mass_migration.go
+++ b/storage/mass_migration.go
@@ -10,10 +10,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-func (s *TransactionStorage) AddMassMigration(tx *models.MassMigration) error {
-	return s.AddTransaction(tx)
-}
-
 func (s *TransactionStorage) BatchAddMassMigration(txs []models.MassMigration) error {
 	return s.BatchAddTransaction(models.MakeMassMigrationArray(txs...))
 }

--- a/storage/mass_migration_test.go
+++ b/storage/mass_migration_test.go
@@ -49,7 +49,7 @@ func (s *MassMigrationTestSuite) TearDownTest() {
 }
 
 func (s *MassMigrationTestSuite) TestAddMassMigration_AddAndRetrieve() {
-	err := s.storage.AddMassMigration(&massMigration)
+	err := s.storage.AddTransaction(&massMigration)
 	s.NoError(err)
 
 	expected := massMigration
@@ -65,7 +65,7 @@ func (s *MassMigrationTestSuite) TestAddMassMigration_AddAndRetrieveIncludedMass
 		BatchID:      models.MakeUint256(3),
 		IndexInBatch: 1,
 	}
-	err := s.storage.AddMassMigration(&includedMassMigration)
+	err := s.storage.AddTransaction(&includedMassMigration)
 	s.NoError(err)
 
 	res, err := s.storage.GetMassMigration(massMigration.Hash)
@@ -128,7 +128,7 @@ func (s *MassMigrationTestSuite) TestMarkMassMigrationsAsIncluded() {
 	for i := 0; i < len(txs); i++ {
 		txs[i] = massMigration
 		txs[i].Hash = utils.RandomHash()
-		err := s.storage.AddMassMigration(&txs[i])
+		err := s.storage.AddTransaction(&txs[i])
 		s.NoError(err)
 	}
 
@@ -150,7 +150,7 @@ func (s *MassMigrationTestSuite) TestGetMassMigrationsByCommitmentID() {
 	massMigration1 := massMigration
 	massMigration1.CommitmentID = &txCommitment.ID
 
-	err := s.storage.AddMassMigration(&massMigration1)
+	err := s.storage.AddTransaction(&massMigration1)
 	s.NoError(err)
 
 	massMigrations, err := s.storage.GetMassMigrationsByCommitmentID(txCommitment.ID)
@@ -167,7 +167,7 @@ func (s *MassMigrationTestSuite) TestGetMassMigrationsByCommitmentID_NoTransacti
 func (s *MassMigrationTestSuite) TestGetMassMigrationsByCommitmentID_NoMassMigrationsButSomeTransfers() {
 	transfer1 := transfer
 	transfer1.CommitmentID = &txCommitment.ID
-	err := s.storage.AddTransfer(&transfer1)
+	err := s.storage.AddTransaction(&transfer1)
 	s.NoError(err)
 
 	massMigrations, err := s.storage.GetMassMigrationsByCommitmentID(txCommitment.ID)

--- a/storage/stored_transaction_test.go
+++ b/storage/stored_transaction_test.go
@@ -37,11 +37,11 @@ func (s *StoredTransactionTestSuite) TearDownTest() {
 }
 
 func (s *StoredTransactionTestSuite) TestSetTransactionErrors() {
-	err := s.storage.AddTransfer(&transfer)
+	err := s.storage.AddTransaction(&transfer)
 	s.NoError(err)
-	err = s.storage.AddCreate2Transfer(&create2Transfer)
+	err = s.storage.AddTransaction(&create2Transfer)
 	s.NoError(err)
-	err = s.storage.AddMassMigration(&massMigration)
+	err = s.storage.AddTransaction(&massMigration)
 	s.NoError(err)
 
 	transferError := models.TxError{
@@ -84,7 +84,7 @@ func (s *StoredTransactionTestSuite) TestMarkTransactionsAsPending() {
 			BatchID:      models.MakeUint256(5),
 			IndexInBatch: 3,
 		}
-		err := s.storage.AddTransfer(&txs[i])
+		err := s.storage.AddTransaction(&txs[i])
 		s.NoError(err)
 	}
 
@@ -116,21 +116,21 @@ func (s *StoredTransactionTestSuite) TestGetTransactionCount() {
 	transferInCommitment := transfer
 	transferInCommitment.Hash = common.Hash{5, 5, 5}
 	transferInCommitment.CommitmentID = &commitmentInBatch.ID
-	err = s.storage.AddTransfer(&transferInCommitment)
+	err = s.storage.AddTransaction(&transferInCommitment)
 	s.NoError(err)
-	err = s.storage.AddTransfer(&transfer)
+	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	c2t := create2Transfer
 	c2t.Hash = common.Hash{3, 4, 5}
 	c2t.CommitmentID = &commitmentInBatch.ID
-	err = s.storage.AddCreate2Transfer(&c2t)
+	err = s.storage.AddTransaction(&c2t)
 	s.NoError(err)
 
 	mm := massMigration
 	mm.Hash = common.Hash{6, 7, 8}
 	mm.CommitmentID = &commitmentInBatch.ID
-	err = s.storage.AddMassMigration(&mm)
+	err = s.storage.AddTransaction(&mm)
 	s.NoError(err)
 
 	count, err := s.storage.GetTransactionCount()
@@ -263,7 +263,7 @@ func (s *StoredTransactionTestSuite) addTransfersInCommitment(batchID *models.Ui
 			BatchID:      *batchID,
 			IndexInBatch: 0,
 		}
-		err := s.storage.AddTransfer(&transfers[i])
+		err := s.storage.AddTransaction(&transfers[i])
 		s.NoError(err)
 	}
 }

--- a/storage/transaction_test.go
+++ b/storage/transaction_test.go
@@ -46,7 +46,7 @@ func (s *TransactionTestSuite) TearDownTest() {
 }
 
 func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_WithoutBatch() {
-	err := s.storage.AddTransfer(&transfer)
+	err := s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	expected := models.TransactionWithBatchDetails{
@@ -63,7 +63,7 @@ func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_Transfer() {
 	transferInBatch.CommitmentID = &models.CommitmentID{
 		BatchID: s.batch.ID,
 	}
-	err := s.storage.AddTransfer(&transferInBatch)
+	err := s.storage.AddTransaction(&transferInBatch)
 	s.NoError(err)
 
 	expected := models.TransactionWithBatchDetails{
@@ -81,7 +81,7 @@ func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_Create2Transfe
 	create2TransferInBatch.CommitmentID = &models.CommitmentID{
 		BatchID: s.batch.ID,
 	}
-	err := s.storage.AddCreate2Transfer(&create2TransferInBatch)
+	err := s.storage.AddTransaction(&create2TransferInBatch)
 	s.NoError(err)
 
 	expected := models.TransactionWithBatchDetails{
@@ -99,7 +99,7 @@ func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_MassMigration(
 	massMigrationInBatch.CommitmentID = &models.CommitmentID{
 		BatchID: s.batch.ID,
 	}
-	err := s.storage.AddMassMigration(&massMigrationInBatch)
+	err := s.storage.AddTransaction(&massMigrationInBatch)
 	s.NoError(err)
 
 	expected := models.TransactionWithBatchDetails{
@@ -115,7 +115,7 @@ func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_MassMigration(
 func (s *TransactionTestSuite) TestUpdateTransaction_UpdatesTx() {
 	failedTx := transfer
 	failedTx.ErrorMessage = ref.String("some message")
-	err := s.storage.AddTransfer(&failedTx)
+	err := s.storage.AddTransaction(&failedTx)
 	s.NoError(err)
 
 	updatedTx := transfer
@@ -133,7 +133,7 @@ func (s *TransactionTestSuite) TestUpdateTransaction_DoesNotUpdateMinedTx() {
 	tx.CommitmentID = &models.CommitmentID{
 		BatchID: models.MakeUint256(1),
 	}
-	err := s.storage.AddCreate2Transfer(&tx)
+	err := s.storage.AddTransaction(&tx)
 	s.NoError(err)
 
 	updatedTx := create2Transfer
@@ -143,7 +143,7 @@ func (s *TransactionTestSuite) TestUpdateTransaction_DoesNotUpdateMinedTx() {
 }
 
 func (s *TransactionTestSuite) TestUpdateTransaction_DoesNotUpdatePendingTx() {
-	err := s.storage.AddMassMigration(&massMigration)
+	err := s.storage.AddTransaction(&massMigration)
 	s.NoError(err)
 
 	updatedTx := massMigration

--- a/storage/transfer.go
+++ b/storage/transfer.go
@@ -12,31 +12,11 @@ import (
 )
 
 func (s *TransactionStorage) AddTransfer(tx *models.Transfer) error {
-	return s.executeInTransaction(TxOptions{}, func(txStorage *TransactionStorage) error {
-		if tx.CommitmentID != nil || tx.ErrorMessage != nil {
-			err := txStorage.addStoredTxReceipt(stored.NewTxReceiptFromTransfer(tx))
-			if err != nil {
-				return err
-			}
-		}
-		return txStorage.addStoredTx(stored.NewTxFromTransfer(tx))
-	})
+	return s.AddTransaction(tx)
 }
 
 func (s *TransactionStorage) BatchAddTransfer(txs []models.Transfer) error {
-	if len(txs) < 1 {
-		return errors.WithStack(ErrNoRowsAffected)
-	}
-
-	return s.executeInTransaction(TxOptions{}, func(txStorage *TransactionStorage) error {
-		for i := range txs {
-			err := txStorage.AddTransfer(&txs[i])
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	})
+	return s.BatchAddTransaction(models.MakeTransferArray(txs...))
 }
 
 func (s *TransactionStorage) GetTransfer(hash common.Hash) (*models.Transfer, error) {

--- a/storage/transfer.go
+++ b/storage/transfer.go
@@ -11,10 +11,6 @@ import (
 	bh "github.com/timshannon/badgerhold/v4"
 )
 
-func (s *TransactionStorage) AddTransfer(tx *models.Transfer) error {
-	return s.AddTransaction(tx)
-}
-
 func (s *TransactionStorage) BatchAddTransfer(txs []models.Transfer) error {
 	return s.BatchAddTransaction(models.MakeTransferArray(txs...))
 }

--- a/storage/transfer_test.go
+++ b/storage/transfer_test.go
@@ -49,7 +49,7 @@ func (s *TransferTestSuite) TearDownTest() {
 }
 
 func (s *TransferTestSuite) TestAddTransfer_AddAndRetrieve() {
-	err := s.storage.AddTransfer(&transfer)
+	err := s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
 	expected := transfer
@@ -65,7 +65,7 @@ func (s *TransferTestSuite) TestAddTransfer_AddAndRetrieveIncludedTransfer() {
 		BatchID:      models.MakeUint256(3),
 		IndexInBatch: 1,
 	}
-	err := s.storage.AddTransfer(&includedTransfer)
+	err := s.storage.AddTransaction(&includedTransfer)
 	s.NoError(err)
 
 	res, err := s.storage.GetTransfer(transfer.Hash)
@@ -74,7 +74,7 @@ func (s *TransferTestSuite) TestAddTransfer_AddAndRetrieveIncludedTransfer() {
 }
 
 func (s *TransferTestSuite) TestGetTransfer_DifferentTxType() {
-	err := s.storage.AddCreate2Transfer(&create2Transfer)
+	err := s.storage.AddTransaction(&create2Transfer)
 	s.NoError(err)
 
 	_, err = s.storage.GetTransfer(create2Transfer.Hash)
@@ -86,7 +86,7 @@ func (s *TransferTestSuite) TestMarkTransfersAsIncluded() {
 	for i := 0; i < len(txs); i++ {
 		txs[i] = transfer
 		txs[i].Hash = utils.RandomHash()
-		err := s.storage.AddTransfer(&txs[i])
+		err := s.storage.AddTransaction(&txs[i])
 		s.NoError(err)
 	}
 
@@ -158,7 +158,7 @@ func (s *TransferTestSuite) TestGetTransfersByCommitmentID() {
 	transfer1 := transfer
 	transfer1.CommitmentID = &txCommitment.ID
 
-	err := s.storage.AddTransfer(&transfer1)
+	err := s.storage.AddTransaction(&transfer1)
 	s.NoError(err)
 
 	transfers, err := s.storage.GetTransfersByCommitmentID(txCommitment.ID)
@@ -175,7 +175,7 @@ func (s *TransferTestSuite) TestGetTransfersByCommitmentID_NoTransactions() {
 func (s *TransferTestSuite) TestGetTransfersByCommitmentID_NoTransfersButSomeCreate2Transfers() {
 	c2t := create2Transfer
 	c2t.CommitmentID = &txCommitment.ID
-	err := s.storage.AddCreate2Transfer(&c2t)
+	err := s.storage.AddTransaction(&c2t)
 	s.NoError(err)
 
 	transfers, err := s.storage.GetTransfersByCommitmentID(txCommitment.ID)


### PR DESCRIPTION
While working on [PRO-38](https://linear.app/worldcoin/issue/PRO-38/change-storedtx-and-storedtxreceipt-into-pendingtx-and-minedtx-tables) I noticed some code duplication, opening a quick PR to remove it.

This should be much easier to review if you look at the individual commits.

TODO:
- The create2 case also included a check for `t.ToStateID`, which I don't think is necessary, but I want to go back and make sure nothing relies on that behavior (which this PR drops)
- There are now some duplicated tests which should be deduplicated.