### PR TITLE
Remove defunct reference to GetCreate2Transfers... from docs

### DIFF
--- a/docs/data_schema.md
+++ b/docs/data_schema.md
@@ -54,7 +54,7 @@ GetUserStateByID (duplicate of GetStateLeafByPath)
 GetUnusedPubKeyID
 - GetAccounts = O(n) - could be O(log(n))
 - for each PubKeyID use {token_index, pub_key_id} => {state_id} index
-GetTransfersByPublicKey + GetCreate2TransfersByPublicKey
+GetTransfersByPublicKey
 - GetAccounts = O(n) - could be O(log(n))
 - get stateIDs using index on pub_key_id (probably using Badger directly)
 


### PR DESCRIPTION
`GetCreate2TransfersByPublicKey` was removed in b802d1d952c3c4cffe476ad8969fea943d291f2c but was not removed from the docs.