### PR TITLE
Make GetRevertMessage method public

### DIFF
--- a/eth/dispute_transition.go
+++ b/eth/dispute_transition.go
@@ -1,13 +1,11 @@
 package eth
 
 import (
-	"context"
 	"math/big"
 
 	"github.com/Worldcoin/hubble-commander/contracts/rollup"
 	"github.com/Worldcoin/hubble-commander/eth/chain"
 	"github.com/Worldcoin/hubble-commander/models"
-	"github.com/ethereum/go-ethereum"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
@@ -128,20 +126,6 @@ func (c *Client) waitForDispute(batchID *models.Uint256, batchHash *common.Hash,
 		return NewDisputeTxRevertedError(batchID.Uint64(), err.Error())
 	}
 	return NewUnknownDisputeTxRevertedError(batchID.Uint64())
-}
-
-func (c *Client) getDisputeRevertMessage(tx *types.Transaction, txReceipt *types.Receipt) error {
-	callMsg := ethereum.CallMsg{
-		From:     c.Blockchain.GetAccount().From,
-		To:       tx.To(),
-		Gas:      tx.Gas(),
-		GasPrice: tx.GasPrice(),
-		Value:    tx.Value(),
-		Data:     tx.Data(),
-	}
-
-	_, err := c.Blockchain.GetBackend().CallContract(context.Background(), callMsg, txReceipt.BlockNumber)
-	return err
 }
 
 func (c *Client) isBatchAlreadyDisputed(batchID *models.Uint256, batchHash *common.Hash) error {

--- a/eth/dispute_transition.go
+++ b/eth/dispute_transition.go
@@ -121,7 +121,7 @@ func (c *Client) waitForDispute(batchID *models.Uint256, batchHash *common.Hash,
 	if err != nil {
 		return err
 	}
-	err = c.getDisputeRevertMessage(tx, receipt)
+	err = c.GetRevertMessage(tx, receipt)
 	if err != nil {
 		return NewDisputeTxRevertedError(batchID.Uint64(), err.Error())
 	}

--- a/eth/utils.go
+++ b/eth/utils.go
@@ -1,0 +1,22 @@
+package eth
+
+import (
+	"context"
+
+	"github.com/ethereum/go-ethereum"
+	"github.com/ethereum/go-ethereum/core/types"
+)
+
+func (c *Client) getDisputeRevertMessage(tx *types.Transaction, txReceipt *types.Receipt) error {
+	callMsg := ethereum.CallMsg{
+		From:     c.Blockchain.GetAccount().From,
+		To:       tx.To(),
+		Gas:      tx.Gas(),
+		GasPrice: tx.GasPrice(),
+		Value:    tx.Value(),
+		Data:     tx.Data(),
+	}
+
+	_, err := c.Blockchain.GetBackend().CallContract(context.Background(), callMsg, txReceipt.BlockNumber)
+	return err
+}

--- a/eth/utils.go
+++ b/eth/utils.go
@@ -7,7 +7,7 @@ import (
 	"github.com/ethereum/go-ethereum/core/types"
 )
 
-func (c *Client) getDisputeRevertMessage(tx *types.Transaction, txReceipt *types.Receipt) error {
+func (c *Client) GetRevertMessage(tx *types.Transaction, txReceipt *types.Receipt) error {
 	callMsg := ethereum.CallMsg{
 		From:     c.Blockchain.GetAccount().From,
 		To:       tx.To(),


### PR DESCRIPTION
This PR renames and makes `GetRevertMessage` public. On multiple occasions now, this method was useful for debugging failing E2E tests, however we always copied its content to create a temporary function in E2E test file that was immediately deleted after fulfilling its purpose. I believe that this change will shorten the time needed to debug E2E tests in the future.