### PR TITLE
Use random keys to fill incomplete account registration batches

### DIFF
--- a/commander/executor/create_create2transfer_commitments.go
+++ b/commander/executor/create_create2transfer_commitments.go
@@ -237,15 +237,18 @@ func (t *TransactionExecutor) fillMissingAccounts(accounts PendingAccounts) (Pen
 	if missingAccounts == 0 {
 		return accounts, nil
 	}
-	publicKey := models.PublicKey{1, 2, 3}
 	for i := 0; i < st.AccountBatchSize-missingAccounts; i++ {
 		pubKeyID, err := accounts.NextPubKeyID(t.storage)
 		if err != nil {
 			return nil, err
 		}
+		randomKey, err := models.NewRandomPublicKey()
+		if err != nil {
+			return nil, err
+		}
 		accounts = append(accounts, models.AccountLeaf{
 			PubKeyID:  *pubKeyID,
-			PublicKey: publicKey,
+			PublicKey: *randomKey,
 		})
 	}
 	return accounts, nil

--- a/models/public_key.go
+++ b/models/public_key.go
@@ -28,6 +28,16 @@ func MakePublicKeyFromInts(ints [4]*big.Int) PublicKey {
 	return publicKey
 }
 
+func NewRandomPublicKey() (*PublicKey, error) {
+	var publicKey PublicKey
+	bytes, err := utils.SafeRandomBytes(PublicKeyLength)
+	if err != nil {
+		return nil, err
+	}
+	copy(publicKey[:], bytes)
+	return &publicKey, nil
+}
+
 // nolint:gocritic
 func (p PublicKey) Bytes() []byte {
 	return p[:]

--- a/utils/random.go
+++ b/utils/random.go
@@ -1,12 +1,22 @@
 package utils
 
 import (
+	crand "crypto/rand"
 	"encoding/hex"
 	"math/big"
 	"math/rand"
 
 	"github.com/ethereum/go-ethereum/common"
 )
+
+func SafeRandomBytes(size uint64) ([]byte, error) {
+	bytes := make([]byte, size)
+	_, err := crand.Read(bytes)
+	if err != nil {
+		return nil, err
+	}
+	return bytes, nil
+}
 
 func RandomBytes(size uint64) []byte {
 	bytes := make([]byte, size)


### PR DESCRIPTION
This PR fixes a problem with an index value growing too large and causing `Txn is too big to fit into one request` error during Badger transaction commitment.

The issue was caused by filling an account registration batch with the same `PublicKey{1, 2, 3}` every time. Effectively this key was registered multiple times and got multiple PubKeyIDs.
The value of index key:
```
_bhIndex:AccountLeaf:PublicKey:0x123... 
```
grew with every new C2T batch.