### PR TITLE
Replace bh.FindOne with bh.Find.Limt(1)

### DIFF
--- a/storage/account.go
+++ b/storage/account.go
@@ -7,19 +7,20 @@ import (
 )
 
 func (s *Storage) GetFirstPubKeyID(publicKey *models.PublicKey) (*uint32, error) {
-	var account models.AccountLeaf
-	err := s.database.Badger.FindOne(
-		&account,
-		bh.Where("PublicKey").Eq(*publicKey).Index("PublicKey"),
+	var accounts []models.AccountLeaf
+	err := s.database.Badger.Find(
+		&accounts,
+		bh.Where("PublicKey").Eq(*publicKey).Index("PublicKey").Limit(1),
 	)
-	if err == bh.ErrNotFound {
-		return nil, errors.WithStack(NewNotFoundError("pub key id"))
-	}
 	if err != nil {
 		return nil, err
 	}
 
-	return &account.PubKeyID, nil
+	if len(accounts) == 0 {
+		return nil, errors.WithStack(NewNotFoundError("pub key id"))
+	}
+
+	return &accounts[0].PubKeyID, nil
 }
 
 func (s *Storage) GetPublicKeyByStateID(stateID uint32) (*models.PublicKey, error) {

--- a/storage/batch.go
+++ b/storage/batch.go
@@ -63,10 +63,10 @@ func (s *BatchStorage) GetMinedBatch(batchID models.Uint256) (*models.Batch, err
 }
 
 func (s *BatchStorage) GetBatchByHash(batchHash common.Hash) (*models.Batch, error) {
-	var storedBatches []stored.Batch
+	storedBatches := make([]stored.Batch, 0, 1)
 	err := s.database.Badger.Find(
 		&storedBatches,
-		bh.Where("Hash").Eq(batchHash).Index("Hash").Limit(1),
+		bh.Where("Hash").Eq(&batchHash).Index("Hash").Limit(1),
 	)
 	if err != nil {
 		return nil, err

--- a/storage/batch.go
+++ b/storage/batch.go
@@ -63,19 +63,20 @@ func (s *BatchStorage) GetMinedBatch(batchID models.Uint256) (*models.Batch, err
 }
 
 func (s *BatchStorage) GetBatchByHash(batchHash common.Hash) (*models.Batch, error) {
-	var storedBatch stored.Batch
-	err := s.database.Badger.FindOne(
-		&storedBatch,
-		bh.Where("Hash").Eq(batchHash).Index("Hash"),
+	var storedBatches []stored.Batch
+	err := s.database.Badger.Find(
+		&storedBatches,
+		bh.Where("Hash").Eq(batchHash).Index("Hash").Limit(1),
 	)
-	if err == bh.ErrNotFound {
-		return nil, errors.WithStack(NewNotFoundError("batch"))
-	}
 	if err != nil {
 		return nil, err
 	}
 
-	return storedBatch.ToModelsBatch(), nil
+	if len(storedBatches) == 0 {
+		return nil, errors.WithStack(NewNotFoundError("batch"))
+	}
+
+	return storedBatches[0].ToModelsBatch(), nil
 }
 
 func (s *BatchStorage) GetPendingBatches() ([]models.Batch, error) {


### PR DESCRIPTION
This change results in faster batch creation for `create2transfer` transactions. The difference:
- `GetFirstPubKeyID` before the change, took `~8%` of the C2T benchmark test
- `GetFirstPubKeyID` after the change, took `~0.04%` of the C2T benchmark test