### PR TITLE
PRO-21: Change primary key of BatchedTx structure

### DIFF
--- a/api/admin/get_pending_batches_test.go
+++ b/api/admin/get_pending_batches_test.go
@@ -172,7 +172,7 @@ func (s *GetPendingBatchesTestSuite) addPendingTransferBatch(tx *models.Transfer
 	err = s.storage.AddCommitment(commitment)
 	s.NoError(err)
 
-	tx.CommitmentID = &commitment.ID
+	tx.CommitmentSlot = models.NewCommitmentSlot(commitment.ID, 0)
 	err = s.storage.AddTransaction(tx)
 	s.NoError(err)
 
@@ -202,7 +202,7 @@ func (s *GetPendingBatchesTestSuite) addPendingCT2Batch(tx *models.Create2Transf
 	err = s.storage.AddCommitment(commitment)
 	s.NoError(err)
 
-	tx.CommitmentID = &commitment.ID
+	tx.CommitmentSlot = models.NewCommitmentSlot(commitment.ID, 0)
 	err = s.storage.AddTransaction(tx)
 	s.NoError(err)
 
@@ -271,7 +271,7 @@ func (s *GetPendingBatchesTestSuite) addCommitmentWithTx(commitment models.Commi
 	err := s.storage.AddCommitment(commitment)
 	s.NoError(err)
 
-	tx.GetBase().CommitmentID = &commitment.GetCommitmentBase().ID
+	tx.GetBase().CommitmentSlot = models.NewCommitmentSlot(commitment.GetCommitmentBase().ID, 0)
 
 	err = s.storage.AddTransaction(tx)
 	s.NoError(err)

--- a/api/calculate_transfer_status.go
+++ b/api/calculate_transfer_status.go
@@ -15,11 +15,11 @@ func CalculateTransactionStatus(
 		return txstatus.Error.Ref(), nil
 	}
 
-	if transfer.CommitmentID == nil {
+	if transfer.CommitmentSlot == nil {
 		return txstatus.Pending.Ref(), nil
 	}
 
-	batch, err := storage.GetBatch(transfer.CommitmentID.BatchID)
+	batch, err := storage.GetBatch(transfer.CommitmentSlot.BatchID)
 	if err != nil {
 		return nil, err
 	}

--- a/api/calculate_transfer_status_test.go
+++ b/api/calculate_transfer_status_test.go
@@ -89,7 +89,7 @@ func (s *CalculateTransactionStatusTestSuite) TestCalculateTransactionStatus_TxI
 	err := s.storage.AddBatch(&batch)
 	s.NoError(err)
 
-	s.transfer.CommitmentID = &models.CommitmentID{
+	s.transfer.CommitmentSlot = &models.CommitmentSlot{
 		BatchID:      batch.ID,
 		IndexInBatch: 0,
 	}
@@ -108,7 +108,7 @@ func (s *CalculateTransactionStatusTestSuite) TestCalculateTransactionStatus_InB
 	err := s.storage.AddBatch(&batch)
 	s.NoError(err)
 
-	s.transfer.CommitmentID = &models.CommitmentID{
+	s.transfer.CommitmentSlot = &models.CommitmentSlot{
 		BatchID: batch.ID,
 	}
 
@@ -129,7 +129,7 @@ func (s *CalculateTransactionStatusTestSuite) TestCalculateTransactionStatus_Fin
 	err = s.storage.AddBatch(&batch)
 	s.NoError(err)
 
-	s.transfer.CommitmentID = &models.CommitmentID{
+	s.transfer.CommitmentSlot = &models.CommitmentSlot{
 		BatchID: batch.ID,
 	}
 

--- a/api/get_commitment_proof_test.go
+++ b/api/get_commitment_proof_test.go
@@ -102,7 +102,7 @@ func (s *GetCommitmentProofTestSuite) TestGetCommitmentProof_TransferType() {
 	s.addStateLeaf()
 
 	transfer := testutils.MakeTransfer(1, 2, 0, 50)
-	transfer.CommitmentID = &s.txCommitment.ID
+	transfer.CommitmentSlot = models.NewCommitmentSlot(s.txCommitment.ID, 0)
 	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
@@ -146,7 +146,7 @@ func (s *GetCommitmentProofTestSuite) TestGetCommitmentProof_Create2TransferType
 	s.addStateLeaf()
 
 	transfer := testutils.MakeCreate2Transfer(1, ref.Uint32(2), 0, 50, &models.PublicKey{2, 3, 4})
-	transfer.CommitmentID = &s.txCommitment.ID
+	transfer.CommitmentSlot = models.NewCommitmentSlot(s.txCommitment.ID, 0)
 	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 
@@ -189,7 +189,7 @@ func (s *GetCommitmentProofTestSuite) TestGetCommitmentProof_MassMigrationType()
 	s.addStateLeaf()
 
 	massMigration := testutils.MakeMassMigration(1, 2, 0, 50)
-	massMigration.CommitmentID = &s.mmCommitment.ID
+	massMigration.CommitmentSlot = models.NewCommitmentSlot(s.mmCommitment.ID, 0)
 	err = s.storage.AddTransaction(&massMigration)
 	s.NoError(err)
 
@@ -245,7 +245,7 @@ func (s *GetCommitmentProofTestSuite) TestGetCommitmentProof_PendingBatch() {
 	s.addStateLeaf()
 
 	transfer := testutils.MakeTransfer(1, 2, 0, 50)
-	transfer.CommitmentID = &s.txCommitment.ID
+	transfer.CommitmentSlot = models.NewCommitmentSlot(s.txCommitment.ID, 0)
 	err = s.storage.AddTransaction(&transfer)
 	s.NoError(err)
 

--- a/api/get_commitment_test.go
+++ b/api/get_commitment_test.go
@@ -110,13 +110,13 @@ func (s *GetCommitmentTestSuite) SetupTest() {
 	}
 
 	s.transfer = testutils.MakeTransfer(1, 2, 0, 100)
-	s.transfer.CommitmentID = &s.txCommitment.ID
+	s.transfer.CommitmentSlot = models.NewCommitmentSlot(s.txCommitment.ID, 0)
 
 	s.create2transfer = testutils.MakeCreate2Transfer(1, ref.Uint32(2), 0, 100, &models.PublicKey{1, 2, 3})
-	s.create2transfer.CommitmentID = &s.txCommitment.ID
+	s.create2transfer.CommitmentSlot = models.NewCommitmentSlot(s.txCommitment.ID, 0)
 
 	s.massMigration = testutils.MakeMassMigration(1, 2, 0, 100)
-	s.massMigration.CommitmentID = &s.mmCommitment.ID
+	s.massMigration.CommitmentSlot = models.NewCommitmentSlot(s.mmCommitment.ID, 0)
 
 	s.commitmentNotFoundAPIErr = &APIError{
 		Code:    20000,

--- a/api/get_mass_migration_commitment_proof_test.go
+++ b/api/get_mass_migration_commitment_proof_test.go
@@ -238,9 +238,10 @@ func (s *GetMassMigrationCommitmentProofTestSuite) generateMassMigrationForTestS
 			0,
 			0,
 			models.NewTimestamp(time.Unix(140, 0).UTC()),
-			models.CommitmentID{
-				BatchID:      models.MakeUint256(1),
-				IndexInBatch: 0,
+			models.CommitmentSlot{
+				BatchID:           models.MakeUint256(1),
+				IndexInBatch:      0,
+				IndexInCommitment: 0,
 			},
 		),
 		makeMassMigration(
@@ -248,9 +249,10 @@ func (s *GetMassMigrationCommitmentProofTestSuite) generateMassMigrationForTestS
 			0,
 			1,
 			models.NewTimestamp(time.Unix(150, 0).UTC()),
-			models.CommitmentID{
-				BatchID:      models.MakeUint256(1),
-				IndexInBatch: 0,
+			models.CommitmentSlot{
+				BatchID:           models.MakeUint256(1),
+				IndexInBatch:      0,
+				IndexInCommitment: 1,
 			},
 		),
 		makeMassMigration(
@@ -258,9 +260,10 @@ func (s *GetMassMigrationCommitmentProofTestSuite) generateMassMigrationForTestS
 			0,
 			2,
 			models.NewTimestamp(time.Unix(160, 0).UTC()),
-			models.CommitmentID{
-				BatchID:      models.MakeUint256(1),
-				IndexInBatch: 1,
+			models.CommitmentSlot{
+				BatchID:           models.MakeUint256(1),
+				IndexInBatch:      1,
+				IndexInCommitment: 2,
 			},
 		),
 	}
@@ -271,20 +274,20 @@ func makeMassMigration(
 	from uint32,
 	nonce uint64,
 	receiveTime *models.Timestamp,
-	commitmentID models.CommitmentID,
+	commitmentSlot models.CommitmentSlot,
 ) models.MassMigration {
 	return models.MassMigration{
 		TransactionBase: models.TransactionBase{
-			Hash:         hash,
-			TxType:       txtype.MassMigration,
-			FromStateID:  from,
-			Amount:       models.MakeUint256(90),
-			Fee:          models.MakeUint256(10),
-			Nonce:        models.MakeUint256(nonce),
-			Signature:    models.MakeRandomSignature(),
-			ReceiveTime:  receiveTime,
-			CommitmentID: &commitmentID,
-			ErrorMessage: nil,
+			Hash:           hash,
+			TxType:         txtype.MassMigration,
+			FromStateID:    from,
+			Amount:         models.MakeUint256(90),
+			Fee:            models.MakeUint256(10),
+			Nonce:          models.MakeUint256(nonce),
+			Signature:      models.MakeRandomSignature(),
+			ReceiveTime:    receiveTime,
+			CommitmentSlot: &commitmentSlot,
+			ErrorMessage:   nil,
 		},
 		SpokeID: 1,
 	}

--- a/api/get_network_info_test.go
+++ b/api/get_network_info_test.go
@@ -111,10 +111,10 @@ func (s *NetworkInfoTestSuite) TestGetNetworkInfo() {
 	s.NoError(err)
 	err = s.api.storage.AddTransaction(&models.Transfer{
 		TransactionBase: models.TransactionBase{
-			Hash:         common.Hash{1, 2, 3},
-			TxType:       txtype.Transfer,
-			FromStateID:  0,
-			CommitmentID: &commitmentInBatch.ID,
+			Hash:           common.Hash{1, 2, 3},
+			TxType:         txtype.Transfer,
+			FromStateID:    0,
+			CommitmentSlot: models.NewCommitmentSlot(commitmentInBatch.ID, 0),
 		},
 		ToStateID: 1,
 	})

--- a/api/get_withdraw_proof_test.go
+++ b/api/get_withdraw_proof_test.go
@@ -46,9 +46,10 @@ func (s *GetWithdrawProofTestSuite) SetupTest() {
 			0,
 			0,
 			models.NewTimestamp(time.Unix(140, 0).UTC()),
-			models.CommitmentID{
-				BatchID:      models.MakeUint256(1),
-				IndexInBatch: 0,
+			models.CommitmentSlot{
+				BatchID:           models.MakeUint256(1),
+				IndexInBatch:      0,
+				IndexInCommitment: 0,
 			},
 		),
 		makeMassMigration(
@@ -56,9 +57,10 @@ func (s *GetWithdrawProofTestSuite) SetupTest() {
 			1,
 			1,
 			models.NewTimestamp(time.Unix(150, 0).UTC()),
-			models.CommitmentID{
-				BatchID:      models.MakeUint256(1),
-				IndexInBatch: 0,
+			models.CommitmentSlot{
+				BatchID:           models.MakeUint256(1),
+				IndexInBatch:      0,
+				IndexInCommitment: 1,
 			},
 		),
 	}

--- a/commander/executor/create_c2t_commitments_test.go
+++ b/commander/executor/create_c2t_commitments_test.go
@@ -44,7 +44,7 @@ func (s *C2TCommitmentsTestSuite) TestCreateCommitments_UpdatesTransactions() {
 	for i := range transfers {
 		tx, err := s.storage.GetCreate2Transfer(transfers[i].Hash)
 		s.NoError(err)
-		s.Equal(commitments[0].ToTxCommitmentWithTxs().ID, *tx.CommitmentID)
+		s.Equal(commitments[0].ToTxCommitmentWithTxs().ID, *tx.CommitmentSlot.CommitmentID())
 		s.Equal(uint32(i+3), *tx.ToStateID)
 		s.Nil(tx.ErrorMessage)
 	}

--- a/commander/executor/create_commitments_test.go
+++ b/commander/executor/create_commitments_test.go
@@ -227,7 +227,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_MarksTransfersAsInclu
 	for i := range transfers {
 		tx, err := s.storage.GetTransfer(transfers[i].Hash)
 		s.NoError(err)
-		s.Equal(commitments[0].ToTxCommitmentWithTxs().ID, *tx.CommitmentID)
+		s.Equal(commitments[0].ToTxCommitmentWithTxs().ID, *tx.CommitmentSlot.CommitmentID())
 		s.Nil(tx.ErrorMessage)
 	}
 }
@@ -248,12 +248,12 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_SkipsNonceTooHighTx()
 		var tx *models.Transfer
 		tx, err = s.storage.GetTransfer(validTxs[i].Hash)
 		s.NoError(err)
-		s.Equal(commitments[0].ToTxCommitmentWithTxs().ID, *tx.CommitmentID)
+		s.Equal(commitments[0].ToTxCommitmentWithTxs().ID, *tx.CommitmentSlot.CommitmentID())
 	}
 
 	tx, err := s.storage.GetTransfer(nonceTooHighTx.Hash)
 	s.NoError(err)
-	s.Nil(tx.CommitmentID)
+	s.Nil(tx.CommitmentSlot)
 	s.Nil(tx.ErrorMessage)
 }
 
@@ -412,7 +412,12 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_SupportsTransactionRe
 
 	minedHigherFeeTransfer, err := s.storage.GetTransfer(higherFeeTransfer.Hash)
 	s.NoError(err)
-	s.Equal(models.MakeUint256(1), minedHigherFeeTransfer.CommitmentID.BatchID)
+
+	expectedCommitmentID := models.CommitmentID{
+		BatchID:      models.MakeUint256(1),
+		IndexInBatch: 0,
+	}
+	s.Equal(expectedCommitmentID, *minedHigherFeeTransfer.CommitmentSlot.CommitmentID())
 }
 
 func (s *CreateCommitmentsTestSuite) initTxs(txs models.GenericTransactionArray) {

--- a/commander/executor/execute_pending_tx_batch_test.go
+++ b/commander/executor/execute_pending_tx_batch_test.go
@@ -73,7 +73,7 @@ func (s *ExecutePendingTxBatchTestSuite) TearDownTest() {
 
 func (s *ExecutePendingTxBatchTestSuite) TestExecutePendingBatch_UpdatesUserBalances() {
 	tx := testutils.MakeTransfer(1, 2, 0, 100)
-	tx.CommitmentID = &s.pendingBatch.Commitments[0].GetCommitmentBase().ID
+	tx.CommitmentSlot = models.NewCommitmentSlot(s.pendingBatch.Commitments[0].GetCommitmentBase().ID, 0)
 	s.pendingBatch.Commitments[0].Transactions = models.TransferArray{tx}
 
 	prevSenderLeaf, err := s.storage.StateTree.Leaf(tx.FromStateID)
@@ -96,7 +96,7 @@ func (s *ExecutePendingTxBatchTestSuite) TestExecutePendingBatch_UpdatesUserBala
 
 func (s *ExecutePendingTxBatchTestSuite) TestExecutePendingBatch_AddsPendingBatch() {
 	tx := testutils.MakeTransfer(1, 2, 0, 100)
-	tx.CommitmentID = &s.pendingBatch.Commitments[0].GetCommitmentBase().ID
+	tx.CommitmentSlot = models.NewCommitmentSlot(s.pendingBatch.Commitments[0].GetCommitmentBase().ID, 0)
 	s.pendingBatch.Commitments[0].Transactions = models.MakeGenericArray(&tx)
 
 	err := s.txsCtx.ExecutePendingBatch(&s.pendingBatch)
@@ -126,7 +126,7 @@ func (s *ExecutePendingTxBatchTestSuite) TestExecutePendingBatch_AddsPendingBatc
 
 func (s *ExecutePendingTxBatchTestSuite) TestExecutePendingBatch_ErrorsOnFailureToApplyAllPendingBatchTxs() {
 	tx := testutils.MakeTransfer(1, 2, 1, 100)
-	tx.CommitmentID = &s.pendingBatch.Commitments[0].GetCommitmentBase().ID
+	tx.CommitmentSlot = models.NewCommitmentSlot(s.pendingBatch.Commitments[0].GetCommitmentBase().ID, 0)
 	s.pendingBatch.Commitments[0].Transactions = models.TransferArray{tx}
 
 	err := s.txsCtx.ExecutePendingBatch(&s.pendingBatch)

--- a/commander/executor/revert_batches.go
+++ b/commander/executor/revert_batches.go
@@ -75,9 +75,9 @@ func (c *ExecutionContext) excludeTransactionsFromCommitment(batchIDs ...models.
 	if len(batchIDs) == 0 {
 		return nil
 	}
-	hashes, err := c.storage.GetTransactionHashesByBatchIDs(batchIDs...)
+	slots, err := c.storage.GetTransactionIDsByBatchIDs(batchIDs...)
 	if err != nil {
 		return err
 	}
-	return c.storage.MarkTransactionsAsPending(hashes)
+	return c.storage.MarkTransactionsAsPending(slots)
 }

--- a/commander/executor/revert_batches_test.go
+++ b/commander/executor/revert_batches_test.go
@@ -79,7 +79,7 @@ func (s *RevertBatchesTestSuite) TestRevertBatches_ExcludesTransactionsFromCommi
 
 	transfer, err := s.storage.GetTransfer(s.transfer.Hash)
 	s.NoError(err)
-	s.Nil(transfer.CommitmentID)
+	s.Nil(transfer.CommitmentSlot)
 }
 
 func (s *RevertBatchesTestSuite) TestRevertBatches_DeletesCommitmentsAndBatches() {

--- a/commander/syncer/sync_tx_commitment.go
+++ b/commander/syncer/sync_tx_commitment.go
@@ -84,8 +84,13 @@ func (c *TxsContext) addTxs(txs models.GenericTransactionArray, commitmentID *mo
 		return nil
 	}
 
+	if txs.Len() > 255 {
+		panic("Commitments cannot have more than 255 transactions")
+	}
+
 	for i := 0; i < txs.Len(); i++ {
-		txs.At(i).GetBase().CommitmentID = commitmentID
+		txs.At(i).GetBase().CommitmentSlot = models.NewCommitmentSlot(*commitmentID, uint8(i))
+
 		hashTransfer, err := c.Syncer.HashTx(txs.At(i))
 		if err != nil {
 			return err

--- a/commander/syncer/txs_sync_c2t_batch_test.go
+++ b/commander/syncer/txs_sync_c2t_batch_test.go
@@ -161,7 +161,7 @@ func (s *SyncC2TBatchTestSuite) TestSyncBatch_SingleBatch() {
 	transfer, err := s.storage.GetCreate2Transfer(tx.Hash)
 	s.NoError(err)
 	transfer.Signature = tx.Signature
-	tx.CommitmentID = &commitment.ToTxCommitment().ID
+	tx.CommitmentSlot = models.NewCommitmentSlot(commitment.ToTxCommitment().ID, 0)
 	tx.ToStateID = transfer.ToStateID
 	s.Equal(tx, *transfer)
 }

--- a/commander/syncer/txs_sync_mm_batch_test.go
+++ b/commander/syncer/txs_sync_mm_batch_test.go
@@ -53,7 +53,7 @@ func (s *SyncMMBatchTestSuite) TestSyncBatch_SingleBatch() {
 	massMigration, err := s.storage.GetMassMigration(tx.Hash)
 	s.NoError(err)
 	massMigration.Signature = tx.Signature
-	tx.CommitmentID = &commitment.ToMMCommitment().ID
+	tx.CommitmentSlot = models.NewCommitmentSlot(commitment.ToMMCommitment().ID, 0)
 	s.Equal(tx, *massMigration)
 }
 

--- a/commander/txs_batches_test.go
+++ b/commander/txs_batches_test.go
@@ -153,7 +153,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_ReplaceLocalBatchWithRemoteOne
 	// Correct tx stored
 	expectedTx := remoteTx
 	expectedTx.Signature = models.Signature{}
-	expectedTx.CommitmentID = &expectedCommitment.ID
+	expectedTx.CommitmentSlot = models.NewCommitmentSlot(expectedCommitment.ID, 0)
 	transfer, err := s.cmd.storage.GetTransfer(remoteTx.Hash)
 	s.NoError(err)
 	s.Equal(expectedTx, *transfer)

--- a/db/encoder.go
+++ b/db/encoder.go
@@ -37,6 +37,10 @@ func Encode(value interface{}) ([]byte, error) {
 		return v.Bytes(), nil
 	case *models.CommitmentID:
 		return v.Bytes(), nil
+	case models.CommitmentSlot:
+		return v.Bytes(), nil
+	case *models.CommitmentSlot:
+		return v.Bytes(), nil
 	case models.PendingDeposit:
 		return v.Bytes(), nil
 	case *models.PendingDeposit:
@@ -136,6 +140,8 @@ func Decode(data []byte, value interface{}) error {
 	case *models.ChainState:
 		return v.SetBytes(data)
 	case *models.CommitmentID:
+		return v.SetBytes(data)
+	case *models.CommitmentSlot:
 		return v.SetBytes(data)
 	case *models.PendingDeposit:
 		return v.SetBytes(data)

--- a/db/iterator.go
+++ b/db/iterator.go
@@ -25,6 +25,8 @@ var (
 		PrefetchValues: false,
 		Reverse:        false,
 	}
+
+	Continue = false
 )
 
 type IteratorFilter func(item *badger.Item) (finish bool, err error)

--- a/db/keylist_test.go
+++ b/db/keylist_test.go
@@ -68,12 +68,12 @@ func TestKeyListMetadata_Bytes(t *testing.T) {
 }
 
 func TestIndexKeyPrefix(t *testing.T) {
-	prefix := IndexKeyPrefix(stored.BatchedTxName, "CommitmentID")
-	require.Equal(t, []byte("_bhIndex:BatchedTx:CommitmentID:"), prefix)
+	prefix := IndexKeyPrefix(stored.BatchedTxName, "Hash")
+	require.Equal(t, []byte("_bhIndex:BatchedTx:Hash:"), prefix)
 }
 
 func TestIndexKey(t *testing.T) {
 	value := stored.EncodeUint32(1)
-	prefix := IndexKey(stored.BatchedTxName, "CommitmentID", value)
-	require.Equal(t, append([]byte("_bhIndex:BatchedTx:CommitmentID:"), value...), prefix)
+	prefix := IndexKey(stored.BatchedTxName, "Hash", value)
+	require.Equal(t, append([]byte("_bhIndex:BatchedTx:Hash:"), value...), prefix)
 }

--- a/docs/badger/data_structures.md
+++ b/docs/badger/data_structures.md
@@ -174,14 +174,14 @@ type TxMassMigrationBody struct {
 
 - Stores transactions which have been added to a batch and submitted to the chain
 
-Key: tx hash `common.Hash`
+Key: (BatchID, IndexInBatch, IndexInCommitment) `models.CommitmentSlot`
 
 Value: `stored.BatchedTx`
 
 ```go
 type BatchedTx struct {
 	PendingTx
-	CommitmentID models.CommitmentID
+	ID stored.CommitmentSlot
 }
 ```
 
@@ -201,12 +201,13 @@ type FailedTx struct {
 }
 ```
 
-#### Index on `CommitmentID`
-Key: commitment ID `models.CommitmentID`
+#### Index on `Hash`
 
-Prefix: `_bhIndex:BatchedTx:CommitmentID:`
+Key: Hash `common.Hash`
 
-Value: list of tx hashes `bh.KeyList`
+Prefix: `_bhIndex:BatchedTx:Hash:`
+
+Value: list `bh.KeyList` with single element, the tx
 
 ## Deposits
 

--- a/models/commitment_id.go
+++ b/models/commitment_id.go
@@ -3,7 +3,7 @@ package models
 const CommitmentIDDataLength = 33
 
 type CommitmentID struct {
-	// GetTransactionHashesByBatchIDs assumes BatchID is the first field
+	// GetTransactionIDsByBatchIDs assumes BatchID is the first field
 	BatchID      Uint256
 	IndexInBatch uint8
 }

--- a/models/commitment_slot.go
+++ b/models/commitment_slot.go
@@ -1,0 +1,50 @@
+package models
+
+import (
+	"bytes"
+)
+
+type CommitmentSlot struct {
+	BatchID           Uint256
+	IndexInBatch      uint8
+	IndexInCommitment uint8
+}
+
+const CommitmentSlotLength = 32 + 1 + 1
+
+func NewCommitmentSlot(commitmentID CommitmentID, indexInCommitment uint8) *CommitmentSlot {
+	return &CommitmentSlot{
+		BatchID:           commitmentID.BatchID,
+		IndexInBatch:      commitmentID.IndexInBatch,
+		IndexInCommitment: indexInCommitment,
+	}
+}
+
+func (k *CommitmentSlot) CommitmentID() *CommitmentID {
+	return &CommitmentID{
+		BatchID:      k.BatchID,
+		IndexInBatch: k.IndexInBatch,
+	}
+}
+
+func (k *CommitmentSlot) Bytes() []byte {
+	var buf bytes.Buffer
+	buf.Grow(CommitmentSlotLength)
+
+	buf.Write(k.BatchID.Bytes())
+	buf.WriteByte(k.IndexInBatch)
+	buf.WriteByte(k.IndexInCommitment)
+
+	return buf.Bytes()
+}
+
+func (k *CommitmentSlot) SetBytes(data []byte) error {
+	if len(data) != CommitmentSlotLength {
+		return ErrInvalidLength
+	}
+
+	k.BatchID.SetBytes(data[0:32])
+	k.IndexInBatch = data[32]
+	k.IndexInCommitment = data[33]
+	return nil
+}

--- a/models/dto/commitment.go
+++ b/models/dto/commitment.go
@@ -12,6 +12,16 @@ type CommitmentID struct {
 	IndexInBatch uint8
 }
 
+func NewCommitmentIDFromSlot(id *models.CommitmentSlot) *CommitmentID {
+	if id == nil {
+		return nil
+	}
+	return &CommitmentID{
+		BatchID:      id.BatchID,
+		IndexInBatch: id.IndexInBatch,
+	}
+}
+
 func NewCommitmentID(id *models.CommitmentID) *CommitmentID {
 	if id == nil {
 		return nil

--- a/models/dto/transaction_base.go
+++ b/models/dto/transaction_base.go
@@ -7,29 +7,29 @@ import (
 )
 
 type TransactionBase struct {
-	Hash         common.Hash
-	TxType       txtype.TransactionType
-	FromStateID  uint32
-	Amount       models.Uint256
-	Fee          models.Uint256
-	Nonce        models.Uint256
-	Signature    models.Signature
-	ReceiveTime  *models.Timestamp
-	CommitmentID *CommitmentID
-	ErrorMessage *string
+	Hash           common.Hash
+	TxType         txtype.TransactionType
+	FromStateID    uint32
+	Amount         models.Uint256
+	Fee            models.Uint256
+	Nonce          models.Uint256
+	Signature      models.Signature
+	ReceiveTime    *models.Timestamp
+	CommitmentSlot *models.CommitmentSlot
+	ErrorMessage   *string
 }
 
 func MakeTransactionBase(tx *models.TransactionBase) TransactionBase {
 	return TransactionBase{
-		Hash:         tx.Hash,
-		TxType:       tx.TxType,
-		FromStateID:  tx.FromStateID,
-		Amount:       tx.Amount,
-		Fee:          tx.Fee,
-		Nonce:        tx.Nonce,
-		Signature:    tx.Signature,
-		ReceiveTime:  tx.ReceiveTime,
-		CommitmentID: NewCommitmentID(tx.CommitmentID),
-		ErrorMessage: tx.ErrorMessage,
+		Hash:           tx.Hash,
+		TxType:         tx.TxType,
+		FromStateID:    tx.FromStateID,
+		Amount:         tx.Amount,
+		Fee:            tx.Fee,
+		Nonce:          tx.Nonce,
+		Signature:      tx.Signature,
+		ReceiveTime:    tx.ReceiveTime,
+		CommitmentSlot: tx.CommitmentSlot,
+		ErrorMessage:   tx.ErrorMessage,
 	}
 }

--- a/models/stored/batched_tx_test.go
+++ b/models/stored/batched_tx_test.go
@@ -26,9 +26,10 @@ func TestBatchedTx_GenericTransactionRoundTrip(t *testing.T) {
 				ToStateID: 2,
 			},
 		},
-		CommitmentID: models.CommitmentID{
-			BatchID:      models.MakeUint256(1),
-			IndexInBatch: 0,
+		ID: models.CommitmentSlot{
+			BatchID:           models.MakeUint256(1),
+			IndexInBatch:      2,
+			IndexInCommitment: 3,
 		},
 	}
 

--- a/models/stored/pending_tx.go
+++ b/models/stored/pending_tx.go
@@ -55,8 +55,8 @@ func (t *PendingTx) ToBase() *models.TransactionBase {
 		ReceiveTime: t.ReceiveTime,
 
 		// These are set for BatchedTx, PendingTx are defined by not having these
-		CommitmentID: nil,
-		ErrorMessage: nil,
+		CommitmentSlot: nil,
+		ErrorMessage:   nil,
 	}
 }
 

--- a/models/stored/sizes.go
+++ b/models/stored/sizes.go
@@ -3,7 +3,8 @@ package stored
 import "github.com/Worldcoin/hubble-commander/models"
 
 const (
-	sizeCommitment      = models.CommitmentIDDataLength
+	sizeCommitmentID    = models.CommitmentIDDataLength
+	sizeCommitmentSlot  = sizeCommitmentID + 1
 	sizeHash            = 32
 	sizeTxType          = 1
 	sizeU32             = 4
@@ -11,5 +12,5 @@ const (
 	sizeSignature       = 64
 	sizeTimestamp       = 16
 	sizePendingTxNoBody = sizeHash + sizeTxType + sizeU32 + 3*sizeU256 + sizeSignature + sizeTimestamp
-	sizeBatchedTxNoBody = sizePendingTxNoBody + sizeCommitment
+	sizeBatchedTxNoBody = sizePendingTxNoBody + sizeCommitmentSlot
 )

--- a/models/transaction_base.go
+++ b/models/transaction_base.go
@@ -8,16 +8,16 @@ import (
 )
 
 type TransactionBase struct {
-	Hash         common.Hash
-	TxType       txtype.TransactionType
-	FromStateID  uint32
-	Amount       Uint256
-	Fee          Uint256
-	Nonce        Uint256
-	Signature    Signature
-	ReceiveTime  *Timestamp
-	CommitmentID *CommitmentID
-	ErrorMessage *string
+	Hash           common.Hash
+	TxType         txtype.TransactionType
+	FromStateID    uint32
+	Amount         Uint256
+	Fee            Uint256
+	Nonce          Uint256
+	Signature      Signature
+	ReceiveTime    *Timestamp
+	CommitmentSlot *CommitmentSlot
+	ErrorMessage   *string
 }
 
 func (t *TransactionBase) GetFromStateID() uint32 {

--- a/storage/create2transfer_test.go
+++ b/storage/create2transfer_test.go
@@ -85,7 +85,7 @@ func (s *Create2TransferTestSuite) TestMarkCreate2TransfersAsIncluded() {
 		err := s.storage.AddTransaction(&txs[i])
 		s.NoError(err)
 
-		txs[i].CommitmentID = commitmentID
+		txs[i].CommitmentSlot = models.NewCommitmentSlot(*commitmentID, uint8(i))
 	}
 
 	err := s.storage.MarkCreate2TransfersAsIncluded(txs, commitmentID)

--- a/storage/mass_migration_test.go
+++ b/storage/mass_migration_test.go
@@ -60,7 +60,7 @@ func (s *MassMigrationTestSuite) TestAddMassMigration_AddAndRetrieve() {
 
 func (s *MassMigrationTestSuite) TestAddMassMigration_AddAndRetrieveIncludedMassMigration() {
 	includedMassMigration := massMigration
-	includedMassMigration.CommitmentID = &models.CommitmentID{
+	includedMassMigration.CommitmentSlot = &models.CommitmentSlot{
 		BatchID:      models.MakeUint256(3),
 		IndexInBatch: 1,
 	}
@@ -121,7 +121,7 @@ func (s *MassMigrationTestSuite) TestMarkMassMigrationsAsIncluded() {
 	for i := range txs {
 		tx, err := s.storage.GetMassMigration(txs[i].Hash)
 		s.NoError(err)
-		s.Equal(commitmentID, *tx.CommitmentID)
+		s.Equal(commitmentID, *tx.CommitmentSlot.CommitmentID())
 	}
 }
 

--- a/storage/transaction_test.go
+++ b/storage/transaction_test.go
@@ -61,7 +61,7 @@ func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_WithoutBatch()
 
 func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_Transfer() {
 	transferInBatch := transfer
-	transferInBatch.CommitmentID = &models.CommitmentID{
+	transferInBatch.CommitmentSlot = &models.CommitmentSlot{
 		BatchID: s.batch.ID,
 	}
 	err := s.storage.AddTransaction(&transferInBatch)
@@ -79,7 +79,7 @@ func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_Transfer() {
 
 func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_Create2Transfer() {
 	create2TransferInBatch := create2Transfer
-	create2TransferInBatch.CommitmentID = &models.CommitmentID{
+	create2TransferInBatch.CommitmentSlot = &models.CommitmentSlot{
 		BatchID: s.batch.ID,
 	}
 	err := s.storage.AddTransaction(&create2TransferInBatch)
@@ -97,7 +97,7 @@ func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_Create2Transfe
 
 func (s *TransactionTestSuite) TestGetTransactionWithBatchDetails_MassMigration() {
 	massMigrationInBatch := massMigration
-	massMigrationInBatch.CommitmentID = &models.CommitmentID{
+	massMigrationInBatch.CommitmentSlot = &models.CommitmentSlot{
 		BatchID: s.batch.ID,
 	}
 	err := s.storage.AddTransaction(&massMigrationInBatch)
@@ -131,7 +131,7 @@ func (s *TransactionTestSuite) TestReplaceFailedTransaction_UpdatesTx() {
 
 func (s *TransactionTestSuite) TestReplaceFailedTransaction_DoesNotUpdateBatchedTx() {
 	tx := create2Transfer
-	tx.CommitmentID = &models.CommitmentID{
+	tx.CommitmentSlot = &models.CommitmentSlot{
 		BatchID: models.MakeUint256(1),
 	}
 	err := s.storage.AddTransaction(&tx)
@@ -155,7 +155,7 @@ func (s *TransactionTestSuite) TestReplaceFailedTransaction_DoesNotUpdatePending
 
 func (s *TransactionTestSuite) TestGetTransactionsByCommitmentID() {
 	transfer1 := transfer
-	transfer1.CommitmentID = &txCommitment.ID
+	transfer1.CommitmentSlot = models.NewCommitmentSlot(txCommitment.ID, 0)
 	err := s.storage.AddTransaction(&transfer1)
 	s.NoError(err)
 
@@ -163,7 +163,7 @@ func (s *TransactionTestSuite) TestGetTransactionsByCommitmentID() {
 	otherCommitmentID.IndexInBatch += 1
 	transfer2 := create2Transfer
 	transfer2.Hash = utils.RandomHash()
-	transfer2.CommitmentID = &otherCommitmentID
+	transfer2.CommitmentSlot = models.NewCommitmentSlot(otherCommitmentID, 0)
 	err = s.storage.AddTransaction(&transfer2)
 	s.NoError(err)
 
@@ -185,9 +185,9 @@ func (s *TransactionTestSuite) TestBatchUpsertTransaction() {
 
 	txBeforeUpsert, err := s.storage.GetTransfer(transfer.Hash)
 	s.NoError(err)
-	s.Nil(txBeforeUpsert.CommitmentID)
+	s.Nil(txBeforeUpsert.CommitmentSlot)
 
-	txBeforeUpsert.CommitmentID = &models.CommitmentID{
+	txBeforeUpsert.CommitmentSlot = &models.CommitmentSlot{
 		BatchID:      models.MakeUint256(1),
 		IndexInBatch: 0,
 	}

--- a/storage/transfer_test.go
+++ b/storage/transfer_test.go
@@ -60,7 +60,7 @@ func (s *TransferTestSuite) TestAddTransfer_AddAndRetrieve() {
 
 func (s *TransferTestSuite) TestAddTransfer_AddAndRetrieveIncludedTransfer() {
 	includedTransfer := transfer
-	includedTransfer.CommitmentID = &models.CommitmentID{
+	includedTransfer.CommitmentSlot = &models.CommitmentSlot{
 		BatchID:      models.MakeUint256(3),
 		IndexInBatch: 1,
 	}
@@ -99,7 +99,7 @@ func (s *TransferTestSuite) TestMarkTransfersAsIncluded() {
 	for i := range txs {
 		tx, err := s.storage.GetTransfer(txs[i].Hash)
 		s.NoError(err)
-		s.Equal(commitmentID, *tx.CommitmentID)
+		s.Equal(commitmentID, *tx.CommitmentSlot.CommitmentID())
 	}
 }
 


### PR DESCRIPTION
I'm not totally satisfied with this yet, I think there's some cleanup which could be done on the `Iterator` calls, and there are probably some tests which should be added, to make sure transactions are always given a reasonable ordering, even during reverts and when syncing form another commander. 

However, asking for a review because I think this is nearly finished, and would like feedback on the general approach!