### PR TITLE
PRO-240: Use db.Continue and db.Break when calling Badger.Iterator

### DIFF
--- a/db/iterator.go
+++ b/db/iterator.go
@@ -27,6 +27,7 @@ var (
 	}
 
 	Continue = false
+	Break    = true
 )
 
 type IteratorFilter func(item *badger.Item) (finish bool, err error)

--- a/storage/account_tree.go
+++ b/storage/account_tree.go
@@ -150,14 +150,14 @@ func (s *AccountTree) NextBatchAccountPubKeyID() (*uint32, error) {
 		var account models.AccountLeaf
 		err = item.Value(account.SetBytes)
 		if err != nil {
-			return false, err
+			return db.Continue, err
 		}
 
 		if account.PubKeyID < AccountBatchOffset {
-			return true, nil
+			return db.Break, nil
 		}
 		nextPubKeyID = account.PubKeyID + 1
-		return true, nil
+		return db.Break, nil
 	})
 	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return nil, err
@@ -170,11 +170,11 @@ func (s *AccountTree) IterateLeaves(action func(stateLeaf *models.AccountLeaf) e
 		var accountLeaf models.AccountLeaf
 		err := item.Value(accountLeaf.SetBytes)
 		if err != nil {
-			return false, err
+			return db.Continue, err
 		}
 
 		err = action(&accountLeaf)
-		return false, err
+		return db.Continue, err
 	})
 	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return err

--- a/storage/batch.go
+++ b/storage/batch.go
@@ -177,7 +177,7 @@ func (s *BatchStorage) reverseIterateBatches(filter func(batch *stored.Batch) bo
 			return db.Decode(v, &storedBatch)
 		})
 		if err != nil {
-			return false, err
+			return db.Continue, err
 		}
 		return filter(&storedBatch), nil
 	})

--- a/storage/deposit.go
+++ b/storage/deposit.go
@@ -59,7 +59,7 @@ func (s *DepositStorage) GetFirstPendingDeposits(amount int) ([]models.PendingDe
 	err := s.database.Badger.Iterator(models.PendingDepositPrefix, keyIteratorOpts, func(item *bdg.Item) (bool, error) {
 		deposit, err := decodeDeposit(item)
 		if err != nil {
-			return false, err
+			return db.Continue, err
 		}
 		deposits = append(deposits, *deposit)
 		return len(deposits) == amount, nil

--- a/storage/deposit_sub_tree.go
+++ b/storage/deposit_sub_tree.go
@@ -31,9 +31,9 @@ func (s *DepositStorage) GetFirstPendingDepositSubtree() (subtree *models.Pendin
 	err = s.database.Badger.Iterator(models.PendingDepositSubtreePrefix, db.KeyIteratorOpts, func(item *bdg.Item) (bool, error) {
 		subtree, err = decodePendingDepositSubtree(item)
 		if err != nil {
-			return false, err
+			return db.Continue, err
 		}
-		return true, nil
+		return db.Break, nil
 	})
 	if errors.Is(err, db.ErrIteratorFinished) {
 		return nil, errors.WithStack(NewNotFoundError("deposit sub tree"))

--- a/storage/pending_stake_withdrawal.go
+++ b/storage/pending_stake_withdrawal.go
@@ -48,13 +48,13 @@ func (s *PendingStakeWithdrawalStorage) GetReadyStateWithdrawals(currentBlock ui
 		func(item *bdg.Item) (bool, error) {
 			err := item.Value(stake.SetBytes)
 			if err != nil {
-				return false, err
+				return db.Continue, err
 			}
 			if stake.FinalisationBlock <= currentBlock {
 				stakes = append(stakes, stake)
-				return false, nil
+				return db.Continue, nil
 			}
-			return true, nil
+			return db.Break, nil
 		})
 	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return nil, err

--- a/storage/stored_transaction.go
+++ b/storage/stored_transaction.go
@@ -224,11 +224,11 @@ func (s *TransactionStorage) getTransactionIDsByBatchID(batchID models.Uint256) 
 	err := s.database.Badger.Iterator(seekPrefix, db.KeyIteratorOpts, func(item *bdg.Item) (bool, error) {
 		err := db.DecodeKey(item.Key(), &id, stored.BatchedTxPrefix)
 		if err != nil {
-			return false, err
+			return db.Continue, err
 		}
 
 		slots = append(slots, id)
-		return false, nil
+		return db.Continue, nil
 	})
 	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return nil, err


### PR DESCRIPTION
Improve code readability by using more meaningful constant names in lieu of `true` and `false`.