### PR TITLE
bug - consistent transaction usage

### DIFF
--- a/storage/stored_transaction.go
+++ b/storage/stored_transaction.go
@@ -320,7 +320,7 @@ func (s *TransactionStorage) MarkTransactionsAsIncluded(
 			if err != nil {
 				return err
 			}
-			s.incrementTransactionCount()
+			txStorage.incrementTransactionCount()
 		}
 		return nil
 	})


### PR DESCRIPTION
Here is a semgrep rule which finds all of these:

```yaml
rules:
  - id: execute-in-transaction
    languages:
      - go
    message: Use of outer transaction inside transaction
    patterns:
      - pattern-inside: $OUTER.executeInTransaction(...)
      - pattern: $OUTER.$ATTR
      - pattern-not: $OUTER.executeInTransaction
    severity: ERROR

```