### PR TITLE
Deployment volume

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -253,7 +253,7 @@ jobs:
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
           --set wipeDisk=true
-          --set volumeID=aws://us-east-1a/vol-000677922f895379c
+          --set persistentStorage.volumeID=aws://us-east-1a/vol-000677922f895379c
   deploy-stage-wipe-setup-manual:
     runs-on: ubuntu-latest
     needs: [build-and-push]
@@ -317,7 +317,7 @@ jobs:
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
           --set wipeDisk=true
-          --set volumeID=aws://us-east-1a/vol-000677922f895379c
+          --set persistentStorage.volumeID=aws://us-east-1a/vol-000677922f895379c
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [ build-and-push, e2e-tests ]

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.2
+          version: v1.45.0
           args: --timeout 2m --build-tags hardhat,e2e
           skip-build-cache: true
           skip-pkg-cache: true

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -253,6 +253,7 @@ jobs:
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
           --set wipeDisk=true
+          --set volumeID=aws://us-east-1a/vol-000677922f895379c
   deploy-stage-wipe-setup-manual:
     runs-on: ubuntu-latest
     needs: [build-and-push]
@@ -316,6 +317,7 @@ jobs:
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
           --set wipeDisk=true
+          --set volumeID=aws://us-east-1a/vol-000677922f895379c
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [ build-and-push, e2e-tests ]

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -316,7 +316,6 @@ jobs:
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
           --set wipeDisk=true
-          --wait
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [ build-and-push, e2e-tests ]

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -277,11 +277,11 @@ jobs:
       - name: Delete setup job
         run: kubectl delete job -n hubble-commander contracts-setup-job --ignore-not-found=true
       - name: Delete Hubble instances
-        run: helm delete -n hubble-commander hubble-commander
+        run: helm delete -n hubble-commander hubble-commander || true
       - name: Delete Geth
         run: helm delete -n hubble-commander geth
       - name: Delete PVCs
-        run: kubectl delete pvc -n hubble-commander geth-data-geth-0 hubble-storage-hubble-commander-0 hubble-storage-hubble-commander-1 --ignore-not-found=true
+        run: kubectl delete pvc -n hubble-commander geth-data-geth-0 --ignore-not-found=true
       - name: Deploy new Geth
         run: helm upgrade --install geth  ./deploy/geth
           --install --atomic --timeout 60s

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.44.0
+          version: v1.44.2
           args: --timeout 2m --build-tags hardhat,e2e
           skip-build-cache: true
           skip-pkg-cache: true

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.43.0
+          version: v1.45.2
           args: --timeout 2m --build-tags hardhat,e2e
           skip-build-cache: true
           skip-pkg-cache: true

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -316,6 +316,7 @@ jobs:
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
           --set wipeDisk=true
+          --wait
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [ build-and-push, e2e-tests ]

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
+          version: v1.44.0
           args: --timeout 2m --build-tags hardhat,e2e
           skip-build-cache: true
           skip-pkg-cache: true

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -252,6 +252,7 @@ jobs:
           --set image.tag="${{ github.sha }}"
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
+          --set wipeDisk=true
   deploy-stage-wipe-setup-manual:
     runs-on: ubuntu-latest
     needs: [build-and-push]
@@ -314,6 +315,7 @@ jobs:
           --set image.tag="${{ github.sha }}"
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
+          --set wipeDisk=true
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [ build-and-push, e2e-tests ]

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.0
-          args: --timeout 2m --build-tags hardhat,e2e
+          version: v1.45.2
+          args: --timeout 5m --build-tags hardhat,e2e
           skip-build-cache: true
           skip-pkg-cache: true
   test-on-hardhat:

--- a/deploy/hubble/templates/ebs-volume.yaml
+++ b/deploy/hubble/templates/ebs-volume.yaml
@@ -1,0 +1,49 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: {{ include "hubble.fullname" . }}
+  labels:
+    {{- include "hubble.labels" . | nindent 4 }}
+  {{- if .Values.wipeDisk }}
+  annotations:
+    "helm.sh/hook": pre-install
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp2
+  awsElasticBlockStore:
+    fsType: ext4
+    volumeID: {{ .Values.persistentStorage.volumeID }}
+  capacity:
+    storage: {{ .Values.persistentStorage.size }}
+  persistentVolumeReclaimPolicy: Retain
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+        - matchExpressions:
+            - key: topology.kubernetes.io/zone
+              operator: In
+              values:
+                - {{ regexFind "\\w+-\\w+-\\w+" .Values.persistentStorage.volumeID }} # aws://us-east-1c/vol-aabbcc123 => us-east-1c
+  claimRef:
+    name: {{ include "hubble.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "hubble.fullname" . }}
+  labels:
+    {{- include "hubble.labels" . | nindent 4 }}
+  {{- if .Values.wipeDisk }}
+  annotations:
+    "helm.sh/hook": pre-install
+  {{- end }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: gp2
+  resources:
+    requests:
+      storage: {{ .Values.persistentStorage.size }}

--- a/deploy/hubble/templates/ebs-volume.yaml
+++ b/deploy/hubble/templates/ebs-volume.yaml
@@ -7,7 +7,7 @@ metadata:
   {{- if .Values.wipeDisk }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "1"
+    "helm.sh/hook-weight": "2"
   {{- end }}
 spec:
   accessModes:
@@ -40,7 +40,7 @@ metadata:
   {{- if .Values.wipeDisk }}
   annotations:
     "helm.sh/hook": pre-install
-    "helm.sh/hook-weight": "2"
+    "helm.sh/hook-weight": "1"
   {{- end }}
 spec:
   accessModes:

--- a/deploy/hubble/templates/ebs-volume.yaml
+++ b/deploy/hubble/templates/ebs-volume.yaml
@@ -7,6 +7,7 @@ metadata:
   {{- if .Values.wipeDisk }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "1"
   {{- end }}
 spec:
   accessModes:
@@ -39,6 +40,7 @@ metadata:
   {{- if .Values.wipeDisk }}
   annotations:
     "helm.sh/hook": pre-install
+    "helm.sh/hook-weight": "2"
   {{- end }}
 spec:
   accessModes:

--- a/deploy/hubble/templates/ebs-wipe.yaml
+++ b/deploy/hubble/templates/ebs-wipe.yaml
@@ -1,0 +1,30 @@
+{{ if .Values.wipeDisk }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: ebs-wipe
+  annotations:
+    # This is what defines this resource as a hook. Without this line, the
+    # job is considered part of the release.
+    "helm.sh/hook": pre-install
+    "helm.sh/hook-delete-policy": hook-succeeded
+spec:
+  completions: 1
+  parallelism: 1
+  backoffLimit: 3
+  ttlSecondsAfterFinished: 0
+  template:
+    spec:
+      restartPolicy: Never
+      volumes:
+        - name: hubble-storage
+          persistentVolumeClaim:
+            claimName: {{ include "hubble.fullname" . }} # same storage as Statefulset
+      containers:
+        - name: disk-wiper
+          image: busybox
+          command: ["rm", "-rf", "/volume/*"]
+          volumeMounts:
+            - name: hubble-storage
+              mountPath: "/volume"
+{{ end }}

--- a/deploy/hubble/templates/ebs-wipe.yaml
+++ b/deploy/hubble/templates/ebs-wipe.yaml
@@ -7,7 +7,6 @@ metadata:
     # This is what defines this resource as a hook. Without this line, the
     # job is considered part of the release.
     "helm.sh/hook": pre-install
-    "helm.sh/hook-delete-policy": hook-succeeded
     "helm.sh/hook-weight": "3"
 spec:
   completions: 1

--- a/deploy/hubble/templates/ebs-wipe.yaml
+++ b/deploy/hubble/templates/ebs-wipe.yaml
@@ -8,6 +8,7 @@ metadata:
     # job is considered part of the release.
     "helm.sh/hook": pre-install
     "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/hook-weight": "3"
 spec:
   completions: 1
   parallelism: 1

--- a/deploy/hubble/templates/statefulset.yaml
+++ b/deploy/hubble/templates/statefulset.yaml
@@ -30,6 +30,9 @@ spec:
         - name: chain-spec-config-volume
           configMap:
             name: chain-spec-config
+        - name: hubble-storage
+          persistentVolumeClaim:
+            claimName: {{ include "hubble.fullname" . }}
       initContainers:
         - name: create-data-dir
           image: busybox:1.28
@@ -126,12 +129,3 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-  volumeClaimTemplates:
-    - metadata:
-        name: hubble-storage
-      spec:
-        accessModes: [ "ReadWriteOnce" ]
-        storageClassName: gp2
-        resources:
-          requests:
-            storage: 100Gi

--- a/deploy/hubble/values.yaml
+++ b/deploy/hubble/values.yaml
@@ -55,6 +55,6 @@ affinity: {}
 
 persistentStorage:
   size: 100Gi
-  volumeID: aws://us-east-1c/vol-aabbcc123 # example: aws://us-east-1c/vol-aabbcc123
+  volumeID: aws://us-east-1a/vol-000677922f895379c # example: aws://us-east-1c/vol-aabbcc123
 
 wipeDisk: false

--- a/deploy/hubble/values.yaml
+++ b/deploy/hubble/values.yaml
@@ -52,3 +52,9 @@ nodeSelector: {}
 tolerations: []
 
 affinity: {}
+
+persistentStorage:
+  size: 100Gi
+  volumeID: aws://us-east-1c/vol-aabbcc123 # example: aws://us-east-1c/vol-aabbcc123
+
+wipeDisk: false

--- a/deploy/hubble/values.yaml
+++ b/deploy/hubble/values.yaml
@@ -55,6 +55,6 @@ affinity: {}
 
 persistentStorage:
   size: 100Gi
-  volumeID: WILL_BE_REPLACED # example: aws://us-east-1c/vol-aabbcc123
+  volumeID: aws://us-east-1a/vol-09a2056485aa974da # example: aws://us-east-1c/vol-aabbcc123
 
 wipeDisk: false

--- a/deploy/hubble/values.yaml
+++ b/deploy/hubble/values.yaml
@@ -55,6 +55,6 @@ affinity: {}
 
 persistentStorage:
   size: 100Gi
-  volumeID: aws://us-east-1a/vol-000677922f895379c # example: aws://us-east-1c/vol-aabbcc123
+  volumeID: WILL_BE_REPLACED # example: aws://us-east-1c/vol-aabbcc123
 
 wipeDisk: false


### PR DESCRIPTION
## Scope
(PR is deployed on stage)

- add statically provisioned volume for persistent storage
- add K8s Job (as Helm pre-install hook) for cleanup volume **if necessary** (for now its manual step)
  - cleanup is done step-by-step: first Helm starts Job objects (as pre-install hook), after finish Helm starts the rest of deployment. Thanks to this we can wipe data on disk, **before** start application. (More info below)
 
### Out of scope
- update golangci-lint to newer version and increase timeout -> because it failed with the previous settings

## How it works?

Default deployment creates `PersistentVolume` and `PersistentVolumeClaim` connected with existing EBS Volume (provisioned via Terraform). It's connected using Retain policy, so create/remove EBS is possible only via Terraform.

Wipe deployment uses Helm feature: [hooks](https://helm.sh/docs/topics/charts_hooks/). This is example code:
```
  {{- if .Values.wipeDisk }}
  annotations:
    "helm.sh/hook": pre-install
    "helm.sh/hook-weight": "2"
  {{- end }}
```

if `wipeDisk` is set to `true`, Helm creates objects in specific order. `pre-install` hook => `Executes after templates are rendered, but before any resources are created in Kubernetes`. This PR contains 3 objects that use `pre-install` hook. These are: `PersistentVolume`, `PersistentVolumeClaim` and `Job`.
Job needs PVC,PV to mount volume and wipe it. After that, Helm creates the rest of deployment objects, for example Statefulset.


`PersistentVolume` connects to EBS volume in [proper Availability Zone](https://github.com/worldcoin/hubble-commander/pull/617/files#diff-8c8a278dbb19a1c2a074811a7fb71b2810c5b0f3fc86e6186f0b422f632e044dR29).