### PR TITLE
Add prometheus metrics for Datadog

### DIFF
--- a/deploy/hubble/templates/statefulset.yaml
+++ b/deploy/hubble/templates/statefulset.yaml
@@ -12,8 +12,18 @@ spec:
   serviceName: hubble-commander-headless
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        ad.datadoghq.com/{{ .Chart.Name }}.check_names: ["openmetrics"]
+        ad.datadoghq.com/{{ .Chart.Name }}.init_configs: [{}]
+        ad.datadoghq.com/{{ .Chart.Name }}.instances: |
+          [
+            {
+              "openmetrics_endpoint": "http://%%host%%:2112/metrics ",
+              "namespace": "{{ .Release.Namespace }}",
+              "metrics": [*]
+            }
+          ]
+      {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
       labels:

--- a/deploy/hubble/templates/statefulset.yaml
+++ b/deploy/hubble/templates/statefulset.yaml
@@ -13,8 +13,10 @@ spec:
   template:
     metadata:
       annotations:
-        ad.datadoghq.com/{{ .Chart.Name }}.check_names: ["openmetrics"]
-        ad.datadoghq.com/{{ .Chart.Name }}.init_configs: [{}]
+        ad.datadoghq.com/{{ .Chart.Name }}.check_names: |
+          ["openmetrics"]
+        ad.datadoghq.com/{{ .Chart.Name }}.init_configs: |
+          [{}]
         ad.datadoghq.com/{{ .Chart.Name }}.instances: |
           [
             {

--- a/deploy/hubble/templates/statefulset.yaml
+++ b/deploy/hubble/templates/statefulset.yaml
@@ -22,7 +22,7 @@ spec:
             {
               "openmetrics_endpoint": "http://%%host%%:2112/metrics ",
               "namespace": "{{ .Release.Namespace }}",
-              "metrics": [*]
+              "metrics": ["*"]
             }
           ]
       {{- with .Values.podAnnotations }}

--- a/deploy/hubble/templates/statefulset.yaml
+++ b/deploy/hubble/templates/statefulset.yaml
@@ -20,9 +20,9 @@ spec:
         ad.datadoghq.com/{{ .Chart.Name }}.instances: |
           [
             {
-              "openmetrics_endpoint": "http://%%host%%:2112/metrics ",
+              "openmetrics_endpoint": "http://%%host%%:2112/metrics",
               "namespace": "{{ .Release.Namespace }}",
-              "metrics": ["*"]
+              "metrics": ["hubble_*"]
             }
           ]
       {{- with .Values.podAnnotations }}


### PR DESCRIPTION
Related to PRO-267

## Explanation for 
```
ad.datadoghq.com/{{ .Chart.Name }}.instances: |
          [
            {
              "openmetrics_endpoint": "http://%%host%%:2112/metrics",
              "namespace": "{{ .Release.Namespace }}",
              "metrics": ["hubble_*"]
            }
          ]
```

- `2112` port is defined [by application](https://github.com/worldcoin/hubble-commander/blob/prometheus-metrics-to-datadog/config/config.go#L22), same as `/metrics` path
-  metrics `hubble_*` are taken from output `curl http://<CONTAINER_IP>:2112/metrics` - all metrics starts with this prefix, so we are getting all metrics to Datadog

### Metrics look like this 
![image](https://user-images.githubusercontent.com/23660445/163385914-ed05bc31-bb1c-491a-b230-d90c943230d3.png)
