### PR TITLE
Rename stored.StateLeaf to support exporting from an older database.

### DIFF
--- a/db/encoder.go
+++ b/db/encoder.go
@@ -61,9 +61,9 @@ func Encode(value interface{}) ([]byte, error) {
 		return v.Bytes(), nil
 	case *models.PublicKey:
 		return nil, errors.WithStack(errPassedByPointer)
-	case stored.StateLeaf:
+	case stored.FlatStateLeaf:
 		return v.Bytes(), nil
-	case *stored.StateLeaf:
+	case *stored.FlatStateLeaf:
 		return nil, errors.WithStack(errPassedByPointer)
 	case models.StateUpdate:
 		return v.Bytes(), nil
@@ -151,7 +151,7 @@ func Decode(data []byte, value interface{}) error {
 		return stored.DecodeHash(data, &v.DataHash)
 	case *models.PublicKey:
 		return v.SetBytes(data)
-	case *stored.StateLeaf:
+	case *stored.FlatStateLeaf:
 		return v.SetBytes(data)
 	case *models.StateUpdate:
 		return v.SetBytes(data)

--- a/models/stored/state_leaf.go
+++ b/models/stored/state_leaf.go
@@ -7,9 +7,9 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-var StateLeafPrefix = models.GetBadgerHoldPrefix(StateLeaf{})
+var StateLeafPrefix = models.GetBadgerHoldPrefix(FlatStateLeaf{})
 
-type StateLeaf struct {
+type FlatStateLeaf struct {
 	StateID  uint32
 	DataHash common.Hash
 	PubKeyID uint32 `badgerhold:"index"`
@@ -18,8 +18,8 @@ type StateLeaf struct {
 	Nonce    models.Uint256
 }
 
-func MakeStateLeaf(leaf *models.StateLeaf) StateLeaf {
-	return StateLeaf{
+func MakeStateLeaf(leaf *models.StateLeaf) FlatStateLeaf {
+	return FlatStateLeaf{
 		StateID:  leaf.StateID,
 		DataHash: leaf.DataHash,
 		PubKeyID: leaf.PubKeyID,
@@ -29,7 +29,7 @@ func MakeStateLeaf(leaf *models.StateLeaf) StateLeaf {
 	}
 }
 
-func (l *StateLeaf) ToModelsStateLeaf() *models.StateLeaf {
+func (l *FlatStateLeaf) ToModelsStateLeaf() *models.StateLeaf {
 	return &models.StateLeaf{
 		StateID:  l.StateID,
 		DataHash: l.DataHash,
@@ -42,7 +42,7 @@ func (l *StateLeaf) ToModelsStateLeaf() *models.StateLeaf {
 	}
 }
 
-func (l *StateLeaf) Bytes() []byte {
+func (l *FlatStateLeaf) Bytes() []byte {
 	b := make([]byte, 136)
 	binary.BigEndian.PutUint32(b[0:4], l.StateID)
 	copy(b[4:36], l.DataHash[:])
@@ -53,7 +53,7 @@ func (l *StateLeaf) Bytes() []byte {
 	return b
 }
 
-func (l *StateLeaf) SetBytes(data []byte) error {
+func (l *FlatStateLeaf) SetBytes(data []byte) error {
 	l.StateID = binary.BigEndian.Uint32(data[0:4])
 	l.DataHash.SetBytes(data[4:36])
 	l.PubKeyID = binary.BigEndian.Uint32(data[36:40])

--- a/models/stored/state_leaf_test.go
+++ b/models/stored/state_leaf_test.go
@@ -9,7 +9,7 @@ import (
 )
 
 func TestStateLeaf_Bytes(t *testing.T) {
-	leaf := StateLeaf{
+	leaf := FlatStateLeaf{
 		StateID:  1,
 		DataHash: utils.RandomHash(),
 		PubKeyID: 2,
@@ -18,7 +18,7 @@ func TestStateLeaf_Bytes(t *testing.T) {
 		Nonce:    models.MakeUint256(5),
 	}
 
-	var decodedLeaf StateLeaf
+	var decodedLeaf FlatStateLeaf
 	_ = decodedLeaf.SetBytes(leaf.Bytes())
 	require.Equal(t, leaf, decodedLeaf)
 }

--- a/storage/state_leaf.go
+++ b/storage/state_leaf.go
@@ -21,7 +21,7 @@ func (s *Storage) GetStateLeavesByPublicKey(publicKey *models.PublicKey) (stateL
 
 	pubKeyIDs := utils.ValueToInterfaceSlice(accounts, "PubKeyID")
 
-	storedStateLeaves := make([]stored.StateLeaf, 0, 1)
+	storedStateLeaves := make([]stored.FlatStateLeaf, 0, 1)
 	err = s.database.Badger.Find(
 		&storedStateLeaves,
 		bh.Where("PubKeyID").In(pubKeyIDs...).Index("PubKeyID").SortBy("StateID"),

--- a/storage/state_tree.go
+++ b/storage/state_tree.go
@@ -39,7 +39,7 @@ func (s *StateTree) Root() (*common.Hash, error) {
 }
 
 func (s *StateTree) Leaf(stateID uint32) (stateLeaf *models.StateLeaf, err error) {
-	var storedLeaf stored.StateLeaf
+	var storedLeaf stored.FlatStateLeaf
 	err = s.database.Badger.Get(stateID, &storedLeaf)
 	if err == bh.ErrNotFound {
 		return nil, errors.WithStack(NewNotFoundError("state leaf"))
@@ -241,7 +241,7 @@ func (s *StateTree) unsafeSet(index uint32, state *models.UserState) (models.Wit
 }
 
 func (s *StateTree) getLeafByPubKeyIDAndTokenID(pubKeyID uint32, tokenID models.Uint256) (*models.StateLeaf, error) {
-	stateLeaves := make([]stored.StateLeaf, 0, 1)
+	stateLeaves := make([]stored.FlatStateLeaf, 0, 1)
 	err := s.database.Badger.Find(
 		&stateLeaves,
 		bh.Where("PubKeyID").Eq(pubKeyID).Index("PubKeyID").And("TokenID").Eq(tokenID),
@@ -281,7 +281,7 @@ func (s *StateTree) revertState(stateUpdate *models.StateUpdate) (*common.Hash, 
 
 func (s *StateTree) IterateLeaves(action func(stateLeaf *models.StateLeaf) error) error {
 	err := s.database.Badger.Iterator(stored.StateLeafPrefix, db.PrefetchIteratorOpts, func(item *bdg.Item) (bool, error) {
-		var stateLeaf stored.StateLeaf
+		var stateLeaf stored.FlatStateLeaf
 		err := item.Value(stateLeaf.SetBytes)
 		if err != nil {
 			return false, err


### PR DESCRIPTION
Puled from the migrate-0.4.0 branch, badger uses reflection when deciding which key to store each record under. By renaming stored.StateLeaf -> stored.FlatStateLeaf our database schema matches the v0.4.0 database schema.