### PR TITLE
Improve error handling

### DIFF
--- a/commander/rollup.go
+++ b/commander/rollup.go
@@ -78,7 +78,7 @@ func (c *Commander) rollupLoopIteration(ctx context.Context, currentBatchType *b
 func (c *Commander) unsafeRollupLoopIteration(ctx context.Context, currentBatchType *batchtype.BatchType) (err error) {
 	err = validateStateRoot(c.storage)
 	if err != nil {
-		return errors.WithStack(err)
+		return err
 	}
 
 	err = c.txPool.UpdateMempool()

--- a/db/db.go
+++ b/db/db.go
@@ -3,6 +3,7 @@ package db
 import (
 	"github.com/Worldcoin/hubble-commander/config"
 	"github.com/dgraph-io/badger/v3"
+	"github.com/pkg/errors"
 	bh "github.com/timshannon/badgerhold/v4"
 )
 
@@ -60,7 +61,11 @@ func (d *Database) View(fn func(txn *badger.Txn) error) error {
 	if d.duringTransaction() {
 		return fn(d.txn)
 	}
-	return d.store.Badger().View(fn)
+	err := d.store.Badger().View(fn)
+	if err != nil {
+		return errors.WithStack(err)
+	}
+	return nil
 }
 
 func (d *Database) RawUpdate(fn func(txn *badger.Txn) error) error {

--- a/storage/account_tree.go
+++ b/storage/account_tree.go
@@ -159,7 +159,7 @@ func (s *AccountTree) NextBatchAccountPubKeyID() (*uint32, error) {
 		nextPubKeyID = account.PubKeyID + 1
 		return true, nil
 	})
-	if err != nil && err != db.ErrIteratorFinished {
+	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return nil, err
 	}
 	return &nextPubKeyID, nil
@@ -176,7 +176,7 @@ func (s *AccountTree) IterateLeaves(action func(stateLeaf *models.AccountLeaf) e
 		err = action(&accountLeaf)
 		return false, err
 	})
-	if err != nil && err != db.ErrIteratorFinished {
+	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return err
 	}
 	return nil

--- a/storage/batch.go
+++ b/storage/batch.go
@@ -186,7 +186,7 @@ func (s *BatchStorage) reverseIterateBatches(filter func(batch *stored.Batch) bo
 		}
 		return filter(&storedBatch), nil
 	})
-	if err == db.ErrIteratorFinished {
+	if errors.Is(err, db.ErrIteratorFinished) {
 		return nil, errors.WithStack(NewNotFoundError("batch"))
 	}
 	if err != nil {

--- a/storage/database.go
+++ b/storage/database.go
@@ -4,6 +4,7 @@ import (
 	"github.com/Worldcoin/hubble-commander/config"
 	"github.com/Worldcoin/hubble-commander/db"
 	bdg "github.com/dgraph-io/badger/v3"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -43,7 +44,7 @@ func (d *Database) BeginTransaction(opts TxOptions) (*db.TxController, *Database
 
 func (d *Database) ExecuteInTransaction(opts TxOptions, fn func(txDatabase *Database) error) error {
 	err := d.unsafeExecuteInTransaction(opts, fn)
-	if err == bdg.ErrConflict {
+	if errors.Is(err, bdg.ErrConflict) {
 		return d.ExecuteInTransaction(opts, fn)
 	}
 	return err

--- a/storage/deposit.go
+++ b/storage/deposit.go
@@ -64,7 +64,7 @@ func (s *DepositStorage) GetFirstPendingDeposits(amount int) ([]models.PendingDe
 		deposits = append(deposits, *deposit)
 		return len(deposits) == amount, nil
 	})
-	if err == db.ErrIteratorFinished {
+	if errors.Is(err, db.ErrIteratorFinished) {
 		return nil, errors.WithStack(ErrRanOutOfPendingDeposits)
 	}
 	if err != nil {

--- a/storage/deposit_sub_tree.go
+++ b/storage/deposit_sub_tree.go
@@ -35,7 +35,7 @@ func (s *DepositStorage) GetFirstPendingDepositSubtree() (subtree *models.Pendin
 		}
 		return true, nil
 	})
-	if err == db.ErrIteratorFinished {
+	if errors.Is(err, db.ErrIteratorFinished) {
 		return nil, errors.WithStack(NewNotFoundError("deposit sub tree"))
 	}
 	return subtree, err

--- a/storage/initialize_index.go
+++ b/storage/initialize_index.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"github.com/Worldcoin/hubble-commander/db"
 	bdg "github.com/dgraph-io/badger/v3"
+	"github.com/pkg/errors"
 	bh "github.com/timshannon/badgerhold/v4"
 )
 
@@ -44,7 +45,7 @@ func indexAlreadyInitialised(database *Database, indexKey []byte) (bool, error) 
 		_, err := txn.Get(indexKey)
 		return err
 	})
-	if err == bdg.ErrKeyNotFound {
+	if errors.Is(err, bdg.ErrKeyNotFound) {
 		return false, nil
 	}
 	if err != nil {

--- a/storage/pending_stake_withdrawal.go
+++ b/storage/pending_stake_withdrawal.go
@@ -56,7 +56,7 @@ func (s *PendingStakeWithdrawalStorage) GetReadyStateWithdrawals(currentBlock ui
 			}
 			return true, nil
 		})
-	if err != nil && err != db.ErrIteratorFinished {
+	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return nil, err
 	}
 	return stakes, nil

--- a/storage/registered_spoke.go
+++ b/storage/registered_spoke.go
@@ -30,7 +30,7 @@ func (s *RegisteredSpokeStorage) AddRegisteredSpoke(registeredSpoke *models.Regi
 func (s *RegisteredSpokeStorage) GetRegisteredSpoke(spokeID models.Uint256) (*models.RegisteredSpoke, error) {
 	var registeredSpoke models.RegisteredSpoke
 	err := s.database.Badger.Get(spokeID, &registeredSpoke)
-	if err == bh.ErrNotFound {
+	if errors.Is(err, bh.ErrNotFound) {
 		return nil, errors.WithStack(NewNotFoundError("registered spoke"))
 	}
 	if err != nil {

--- a/storage/state_tree.go
+++ b/storage/state_tree.go
@@ -95,7 +95,7 @@ func (s *StateTree) NextVacantSubtree(subtreeDepth uint8) (*uint32, error) {
 		prevTakenNodeIndex = currentNodeIndex
 		return false, nil
 	})
-	if err == db.ErrIteratorFinished { // We finished without finding any gaps, try to append the subtree at the end.
+	if errors.Is(err, db.ErrIteratorFinished) { // We finished without finding any gaps, try to append the subtree at the end.
 		roundedNodeIndex := roundAndValidateStateTreeSlot(prevTakenNodeIndex+1, StateTreeSize, subtreeWidth)
 		if roundedNodeIndex == nil {
 			return nil, errors.WithStack(NewNoVacantSubtreeError(subtreeDepth))
@@ -175,7 +175,7 @@ func (s *StateTree) RevertTo(targetRootHash common.Hash) error {
 			}
 			return *currentRootHash == targetRootHash, nil
 		})
-		if err != nil && err != db.ErrIteratorFinished {
+		if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 			return errors.WithStack(err)
 		}
 
@@ -290,7 +290,7 @@ func (s *StateTree) IterateLeaves(action func(stateLeaf *models.StateLeaf) error
 		err = action(stateLeaf.ToModelsStateLeaf())
 		return false, err
 	})
-	if err != nil && err != db.ErrIteratorFinished {
+	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return err
 	}
 	return nil

--- a/storage/stored_commitment.go
+++ b/storage/stored_commitment.go
@@ -45,7 +45,7 @@ func (s *CommitmentStorage) GetLatestCommitment() (*models.CommitmentBase, error
 		storedCommitment, err = decodeStoredCommitment(item)
 		return true, err
 	})
-	if err == db.ErrIteratorFinished {
+	if errors.Is(err, db.ErrIteratorFinished) {
 		return nil, errors.WithStack(NewNotFoundError("commitment"))
 	}
 	if err != nil {
@@ -92,7 +92,7 @@ func (s *CommitmentStorage) getStoredCommitmentsByBatchID(batchID models.Uint256
 		storedCommitments = append(storedCommitments, *commitment)
 		return false, nil
 	})
-	if err != nil && err != db.ErrIteratorFinished {
+	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return nil, err
 	}
 	return storedCommitments, nil
@@ -119,7 +119,7 @@ func getCommitmentIDsByBatchID(txn *Database, batchID models.Uint256) ([]models.
 		ids = append(ids, id)
 		return false, nil
 	})
-	if err != nil && err != db.ErrIteratorFinished {
+	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return nil, err
 	}
 	return ids, nil

--- a/storage/stored_transaction.go
+++ b/storage/stored_transaction.go
@@ -236,7 +236,7 @@ func (s *TransactionStorage) GetTransactionHashesByBatchIDs(batchIDs ...models.U
 		}
 		return false, nil
 	})
-	if err != nil && err != db.ErrIteratorFinished {
+	if err != nil && !errors.Is(err, db.ErrIteratorFinished) {
 		return nil, err
 	}
 	if len(hashes) == 0 {


### PR DESCRIPTION
- At the end of the commander tests the rollup loop often crashes.
  Previously the stack trace it crashed with was very uninformative,
  this change fixes the stack trace and tells us exactly where the loop
  is crashing (this change does not fix the crashes, which are probably
  unclean shutdowns)

- We were checking for exact error equality in a bunch of places which
  prevented us from wrapping any errors as they entered our control. Now
  we use errors.Is in many more places. errors.Is does the correct thing
  when we give it wrapped errors.