### PR TITLE
Cleanly shutdown rollup loop in tests

### DIFF
--- a/commander/new_block_test.go
+++ b/commander/new_block_test.go
@@ -65,6 +65,7 @@ func (s *NewBlockLoopTestSuite) SetupTest() {
 }
 
 func (s *NewBlockLoopTestSuite) TearDownTest() {
+	s.cmd.stopWorkersAndWait()
 	stopCommander(s.cmd)
 	s.client.Close()
 	err := s.storage.Teardown()

--- a/commander/sync_stake_withdrawals_test.go
+++ b/commander/sync_stake_withdrawals_test.go
@@ -58,6 +58,7 @@ func (s *SyncStakeWithdrawalsTestSuite) SetupTest() {
 }
 
 func (s *SyncStakeWithdrawalsTestSuite) TearDownTest() {
+	s.cmd.stopWorkersAndWait()
 	stopCommander(s.cmd)
 	s.client.Close()
 	err := s.storage.Teardown()


### PR DESCRIPTION
Previously the rollup loop would crash and emit a stack trace even though the test had passed and everything had gone as expected, now the test output is cleaner.