### PR TITLE
B-619 ci: Use a new cluster for staging

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Connect to EKS cluster
         run: aws eks update-kubeconfig
           --region ${{ secrets.AWS_STAGE_REGION }}
-          --name ${{ secrets.AWS_STAGE_CLUSTER }}
+          --name crypto-stage-us-east-1
       - name: Delete setup job
         run: kubectl delete job -n hubble-commander contracts-setup-job --ignore-not-found=true
       - name: Delete Geth
@@ -300,7 +300,7 @@ jobs:
       - name: Connect to EKS cluster
         run: aws eks update-kubeconfig
           --region ${{ secrets.AWS_STAGE_REGION }}
-          --name ${{ secrets.AWS_STAGE_CLUSTER }}
+          --name crypto-stage-us-east-1
       - name: Helm install
         run: helm upgrade "${{ github.event.repository.name }}" ./deploy/hubble
           --install --atomic --timeout 60s

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -249,7 +249,7 @@ jobs:
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
           --set wipeDisk=true
-          --set persistentStorage.volumeID=aws://us-east-1a/vol-000677922f895379c
+          --set persistentStorage.volumeID=aws://us-east-1a/vol-065fd87c2124454e6
   deploy-stage-wipe-setup-manual:
     runs-on: ubuntu-latest
     needs: [build-and-push]
@@ -309,7 +309,7 @@ jobs:
           --set ingress.host=hubble.stage-crypto.worldcoin.dev
           --set environment=stage
           --set wipeDisk=true
-          --set persistentStorage.volumeID=aws://us-east-1a/vol-000677922f895379c
+          --set persistentStorage.volumeID=aws://us-east-1a/vol-065fd87c2124454e6
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [ build-and-push, e2e-tests ]

--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -270,7 +270,7 @@ jobs:
       - name: Connect to EKS cluster
         run: aws eks update-kubeconfig
           --region ${{ secrets.AWS_STAGE_REGION }}
-          --name crypto-stage-us-east-1
+          --name ${{ secrets.AWS_STAGE_CLUSTER }}
       - name: Delete setup job
         run: kubectl delete job -n hubble-commander contracts-setup-job --ignore-not-found=true
       - name: Delete Geth
@@ -300,7 +300,7 @@ jobs:
       - name: Connect to EKS cluster
         run: aws eks update-kubeconfig
           --region ${{ secrets.AWS_STAGE_REGION }}
-          --name crypto-stage-us-east-1
+          --name ${{ secrets.AWS_STAGE_CLUSTER }}
       - name: Helm install
         run: helm upgrade "${{ github.event.repository.name }}" ./deploy/hubble
           --install --atomic --timeout 60s


### PR DESCRIPTION
We recreated the new EKS cluster with security improvements.

Before merge:

- [ ] change EKS name in the AWS_STAGE_CLUSTER secret