### PR TITLE
Close commander in tests even when Start function was not called

### DIFF
--- a/commander/deposit_batches_test.go
+++ b/commander/deposit_batches_test.go
@@ -77,7 +77,7 @@ func newClientWithGenesisState(t *testing.T, storage *st.TestStorage) *eth.TestC
 }
 
 func (s *DepositBatchesTestSuite) TearDownTest() {
-	stopCommander(s.cmd)
+	s.cmd.stopWorkersAndWait()
 	s.client.Close()
 	err := s.storage.Teardown()
 	s.NoError(err)

--- a/commander/migrate_test.go
+++ b/commander/migrate_test.go
@@ -76,7 +76,7 @@ func (s *MigrateTestSuite) SetupTest() {
 }
 
 func (s *MigrateTestSuite) TearDownTest() {
-	stopCommander(s.cmd)
+	s.cmd.stopWorkersAndWait()
 	err := s.storage.Teardown()
 	s.NoError(err)
 }

--- a/commander/mm_batches_test.go
+++ b/commander/mm_batches_test.go
@@ -52,7 +52,7 @@ func (s *MMBatchesTestSuite) SetupTest() {
 }
 
 func (s *MMBatchesTestSuite) TearDownTest() {
-	stopCommander(s.cmd)
+	s.cmd.stopWorkersAndWait()
 	s.client.Close()
 	err := s.storage.Teardown()
 	s.NoError(err)

--- a/commander/new_block_test.go
+++ b/commander/new_block_test.go
@@ -280,13 +280,6 @@ func setStateLeaves(t *testing.T, storage *st.Storage) {
 	require.NoError(t, err)
 }
 
-func stopCommander(cmd *Commander) {
-	if !cmd.isActive() {
-		return
-	}
-	cmd.stopWorkersAndWait()
-}
-
 func TestNewBlockLoopTestSuite(t *testing.T) {
 	suite.Run(t, new(NewBlockLoopTestSuite))
 }

--- a/commander/new_block_test.go
+++ b/commander/new_block_test.go
@@ -66,7 +66,6 @@ func (s *NewBlockLoopTestSuite) SetupTest() {
 
 func (s *NewBlockLoopTestSuite) TearDownTest() {
 	s.cmd.stopWorkersAndWait()
-	stopCommander(s.cmd)
 	s.client.Close()
 	err := s.storage.Teardown()
 	s.NoError(err)

--- a/commander/sync_stake_withdrawals_test.go
+++ b/commander/sync_stake_withdrawals_test.go
@@ -59,7 +59,6 @@ func (s *SyncStakeWithdrawalsTestSuite) SetupTest() {
 
 func (s *SyncStakeWithdrawalsTestSuite) TearDownTest() {
 	s.cmd.stopWorkersAndWait()
-	stopCommander(s.cmd)
 	s.client.Close()
 	err := s.storage.Teardown()
 	s.NoError(err)

--- a/commander/sync_stake_withdrawals_test.go
+++ b/commander/sync_stake_withdrawals_test.go
@@ -93,7 +93,7 @@ func (s *SyncStakeWithdrawalsTestSuite) TestNewBlockLoop_DoesNotSendStakeWithdra
 		"timeout when waiting for StakeWithdrawEvent",
 	)
 
-	stopCommander(s.cmd)
+	s.cmd.stopWorkersAndWait()
 
 	startBlock, err := s.client.GetLatestBlockNumber()
 	s.NoError(err)

--- a/commander/txs_batches_test.go
+++ b/commander/txs_batches_test.go
@@ -68,7 +68,7 @@ func (s *TxsBatchesTestSuite) SetupTest() {
 }
 
 func (s *TxsBatchesTestSuite) TearDownTest() {
-	stopCommander(s.cmd)
+	s.cmd.stopWorkersAndWait()
 	s.client.Close()
 	err := s.storage.Teardown()
 	s.NoError(err)


### PR DESCRIPTION
As it was correctly observed in https://github.com/worldcoin/hubble-commander/pull/624 we should shutdown commander in tests even when `Start` function wasn't called. 
I replaced usages of `stopCommander` function that depends on `isActive` flag with direct commander close method.
Also deduplicated function calls in tests that already calls `stopWorkersAndWait`.