### PR TITLE
Use a custom fork of ristretto, add arm64 linux support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,10 @@ module github.com/Worldcoin/hubble-commander
 
 go 1.17
 
+// fixes a bug with mremap on arm64 linux, without this we get weird errors from badger
+// which look a lot like database corruption
+replace github.com/dgraph-io/ristretto => github.com/lithp/ristretto v0.1.0-hotfix
+
 require (
 	github.com/dgraph-io/badger/v3 v3.2103.1
 	github.com/docker/docker v17.12.0-ce-rc1.0.20200618181300-9dc6525e6118+incompatible

--- a/go.sum
+++ b/go.sum
@@ -608,6 +608,8 @@ github.com/labstack/echo/v4 v4.2.1/go.mod h1:AA49e0DZ8kk5jTOOCKNuPR6oTnBS0dYiM4F
 github.com/labstack/gommon v0.3.0/go.mod h1:MULnywXg0yavhxWKc+lOruYdAhDwPK9wf0OL7NoOu+k=
 github.com/leanovate/gopter v0.2.9/go.mod h1:U2L/78B+KVFIx2VmW6onHJQzXtFb+p5y3y2Sh+Jxxv8=
 github.com/lib/pq v1.0.0/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=
+github.com/lithp/ristretto v0.1.0-hotfix h1:6hjM3rWUCfCtnMdiBaRklt2MoUDmj8h6UXR1AEbC2iw=
+github.com/lithp/ristretto v0.1.0-hotfix/go.mod h1:fux0lOrBhrVCJd3lcTHsIJhq1T2rokOu6v9Vcb3Q9ug=
 github.com/magiconair/properties v1.8.0/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=
 github.com/magiconair/properties v1.8.1 h1:ZC2Vc7/ZFkGmsVC9KvOjumD+G5lXy2RtTKyzRKO2BQ4=
 github.com/magiconair/properties v1.8.1/go.mod h1:PppfXfuXeibc/6YijjN8zIbojt8czPbwD3XqdrwzmxQ=


### PR DESCRIPTION
Using a fork of ristretto under my name: https://github.com/lithp/ristretto/releases/tag/v0.1.0-hotfix

This is v0.1.0 with one additional cherry-picked commit: https://github.com/lithp/ristretto/commit/4c2f84d7905791d8d48e73cc6cd8fae695644d44

Long-term we might want to fork ristretto into the worldcoin org