### PR TITLE
Extract SyncedBlock from ChainState record

### DIFF
--- a/api/handle_transfer_test.go
+++ b/api/handle_transfer_test.go
@@ -37,7 +37,6 @@ var (
 		DepositManager:                 utils.RandomAddress(),
 		WithdrawManager:                utils.RandomAddress(),
 		Rollup:                         utils.RandomAddress(),
-		SyncedBlock:                    11293,
 		GenesisAccounts: []models.GenesisAccount{
 			{
 				PublicKey: models.PublicKey{4, 4, 1, 9},

--- a/commander/chain_spec.go
+++ b/commander/chain_spec.go
@@ -59,6 +59,5 @@ func newChainStateFromChainSpec(chainSpec *models.ChainSpec) *models.ChainState 
 		WithdrawManager:                chainSpec.WithdrawManager,
 		Rollup:                         chainSpec.Rollup,
 		GenesisAccounts:                chainSpec.GenesisAccounts,
-		SyncedBlock:                    getInitialSyncedBlock(chainSpec.AccountRegistryDeploymentBlock),
 	}
 }

--- a/commander/chain_spec_test.go
+++ b/commander/chain_spec_test.go
@@ -63,7 +63,6 @@ func (s *ChainSpecTestSuite) SetupTest() {
 				},
 			},
 		},
-		SyncedBlock: 7738,
 	}
 	s.chainSpec = makeChainSpec(s.chainState)
 }

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -295,6 +295,12 @@ func setGenesisStateAndCreateClient(
 		return nil, err
 	}
 
+	initialSyncedBlock := getInitialSyncedBlock(chainState.AccountRegistryDeploymentBlock)
+	err = storage.SetSyncedBlock(initialSyncedBlock)
+	if err != nil {
+		return nil, err
+	}
+
 	client, err := createClientFromChainState(blockchain, chainState, cfg, commanderMetrics, txsChannels)
 	if err != nil {
 		return nil, err
@@ -333,7 +339,6 @@ func fetchChainStateFromRemoteNode(url string) (*models.ChainState, error) {
 		WithdrawManager:                info.WithdrawManager,
 		Rollup:                         info.Rollup,
 		GenesisAccounts:                genesisAccounts,
-		SyncedBlock:                    getInitialSyncedBlock(info.AccountRegistryDeploymentBlock),
 	}, nil
 }
 

--- a/commander/commander_test.go
+++ b/commander/commander_test.go
@@ -57,7 +57,10 @@ func (s *CommanderTestSuite) TestStart_SetsCorrectSyncedBlock() {
 	err := s.cmd.Start()
 	s.NoError(err)
 
-	s.Equal(s.cmd.client.ChainState.AccountRegistryDeploymentBlock-1, s.cmd.client.ChainState.SyncedBlock)
+	blk, err := s.cmd.storage.GetSyncedBlock()
+	s.NoError(err)
+
+	s.Equal(s.cmd.client.ChainState.AccountRegistryDeploymentBlock-1, *blk)
 
 	err = s.cmd.Stop()
 	s.NoError(err)

--- a/commander/deploy.go
+++ b/commander/deploy.go
@@ -117,6 +117,12 @@ func deployContractsAndSetupGenesisState(
 		return nil, err
 	}
 
+	initialSyncedBlock := getInitialSyncedBlock(*accountRegistryDeploymentBlock)
+	err = storage.SetSyncedBlock(initialSyncedBlock)
+	if err != nil {
+		return nil, err
+	}
+
 	chainState = &models.ChainState{
 		ChainID:                        blockchain.GetChainID(),
 		AccountRegistry:                *accountRegistryAddress,
@@ -127,7 +133,6 @@ func deployContractsAndSetupGenesisState(
 		WithdrawManager:                contracts.WithdrawManagerAddress,
 		Rollup:                         contracts.RollupAddress,
 		GenesisAccounts:                cfg.Bootstrap.GenesisAccounts,
-		SyncedBlock:                    getInitialSyncedBlock(*accountRegistryDeploymentBlock),
 	}
 
 	return chainState, nil

--- a/commander/new_block_test.go
+++ b/commander/new_block_test.go
@@ -207,9 +207,11 @@ func (s *NewBlockLoopTestSuite) setAccountsAndChainState() {
 
 func setChainState(t *testing.T, storage *st.TestStorage) {
 	err := storage.SetChainState(&models.ChainState{
-		ChainID:     models.MakeUint256(1337),
-		SyncedBlock: 0,
+		ChainID: models.MakeUint256(1337),
 	})
+	require.NoError(t, err)
+
+	err = storage.SetSyncedBlock(0)
 	require.NoError(t, err)
 }
 

--- a/docs/badger/data_structures.md
+++ b/docs/badger/data_structures.md
@@ -372,7 +372,6 @@ type ChainState struct {
     TokenRegistry                  common.Address
     DepositManager                 common.Address
     Rollup                         common.Address
-    SyncedBlock                    uint64
     GenesisAccounts                []PopulatedGenesisAccount
 }
 

--- a/eth/test_client.go
+++ b/eth/test_client.go
@@ -59,7 +59,6 @@ func NewConfiguredTestClient(cfg *rollup.DeploymentConfig, clientCfg *TestClient
 			SpokeRegistry:                  contracts.SpokeRegistryAddress,
 			DepositManager:                 contracts.DepositManagerAddress,
 			Rollup:                         contracts.RollupAddress,
-			SyncedBlock:                    0,
 			GenesisAccounts:                nil,
 		},
 		Rollup:          contracts.Rollup,

--- a/models/chain_state.go
+++ b/models/chain_state.go
@@ -6,7 +6,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 )
 
-const baseChainStateDataLength = 168
+const baseChainStateDataLength = 160
 
 type ChainState struct {
 	ChainID                        Uint256
@@ -17,7 +17,6 @@ type ChainState struct {
 	DepositManager                 common.Address
 	WithdrawManager                common.Address
 	Rollup                         common.Address
-	SyncedBlock                    uint64
 	GenesisAccounts                GenesisAccounts `json:"-"`
 }
 
@@ -75,7 +74,6 @@ func (s *ChainState) Bytes() []byte {
 	copy(b[100:120], s.DepositManager.Bytes())
 	copy(b[120:140], s.WithdrawManager.Bytes())
 	copy(b[140:160], s.Rollup.Bytes())
-	binary.BigEndian.PutUint64(b[160:168], s.SyncedBlock)
 
 	for i := range s.GenesisAccounts {
 		start := baseChainStateDataLength + i*populatedGenesisAccountByteSize
@@ -102,7 +100,6 @@ func (s *ChainState) SetBytes(data []byte) error {
 	s.DepositManager.SetBytes(data[100:120])
 	s.WithdrawManager.SetBytes(data[120:140])
 	s.Rollup.SetBytes(data[140:160])
-	s.SyncedBlock = binary.BigEndian.Uint64(data[160:168])
 
 	genesisAccountsCount := (dataLength - baseChainStateDataLength) / populatedGenesisAccountByteSize
 

--- a/models/chain_state_test.go
+++ b/models/chain_state_test.go
@@ -16,7 +16,6 @@ var testChainState = ChainState{
 	DepositManager:                 utils.RandomAddress(),
 	WithdrawManager:                utils.RandomAddress(),
 	Rollup:                         utils.RandomAddress(),
-	SyncedBlock:                    8001,
 	GenesisAccounts: GenesisAccounts{
 		{
 			PublicKey: PublicKey{1, 2, 0, 5, 4},

--- a/storage/block_number.go
+++ b/storage/block_number.go
@@ -2,7 +2,13 @@ package storage
 
 import (
 	"sync/atomic"
+
+	"github.com/Worldcoin/hubble-commander/models/stored"
+	"github.com/dgraph-io/badger/v3"
+	"github.com/pkg/errors"
 )
+
+var SyncedBlockKey = []byte("SyncedBlock")
 
 func (s *ChainStateStorage) SetLatestBlockNumber(blockNumber uint32) {
 	atomic.StoreUint32(&s.latestBlockNumber, blockNumber)
@@ -14,12 +20,11 @@ func (s *ChainStateStorage) GetLatestBlockNumber() uint32 {
 
 func (s *ChainStateStorage) SetSyncedBlock(blockNumber uint64) error {
 	atomic.StoreUint64(&s.syncedBlock, blockNumber)
-	chainState, err := s.GetChainState()
-	if err != nil {
-		return err
-	}
-	chainState.SyncedBlock = blockNumber
-	return s.SetChainState(chainState)
+
+	return s.database.Badger.RawUpdate(func(txn *badger.Txn) error {
+		value := stored.EncodeUint64(blockNumber)
+		return txn.Set(SyncedBlockKey, value)
+	})
 }
 
 func (s *ChainStateStorage) GetSyncedBlock() (*uint64, error) {
@@ -27,14 +32,34 @@ func (s *ChainStateStorage) GetSyncedBlock() (*uint64, error) {
 	if syncedBlock != 0 {
 		return &syncedBlock, nil
 	}
-	chainState, err := s.GetChainState()
-	if IsNotFoundError(err) {
-		return &syncedBlock, nil
+
+	err := s.database.Badger.View(func(txn *badger.Txn) error {
+		item, err := txn.Get(SyncedBlockKey)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		err = item.Value(func(val []byte) error {
+			innerErr := stored.DecodeUint64(val, &syncedBlock)
+			if innerErr != nil {
+				panic("stored.DecodeUint64 never returns error")
+			}
+			return nil
+		})
+		if err != nil {
+			return errors.WithStack(err)
+		}
+
+		return nil
+	})
+	if errors.Is(err, badger.ErrKeyNotFound) {
+		zero := uint64(0)
+		return &zero, nil
 	}
 	if err != nil {
 		return nil, err
 	}
 
-	atomic.StoreUint64(&s.syncedBlock, chainState.SyncedBlock)
-	return &chainState.SyncedBlock, nil
+	atomic.StoreUint64(&s.syncedBlock, syncedBlock)
+	return &syncedBlock, nil
 }

--- a/storage/block_number_test.go
+++ b/storage/block_number_test.go
@@ -40,13 +40,13 @@ func (s *BlockNumberTestSuite) TestSetLatestBlockNumber() {
 }
 
 func (s *BlockNumberTestSuite) TestGetSyncedBlock() {
-	err := s.storage.SetChainState(&chainState)
+	err := s.storage.SetSyncedBlock(10)
 	s.NoError(err)
 
 	syncedBlock, err := s.storage.GetSyncedBlock()
 	s.NoError(err)
 
-	s.Equal(chainState.SyncedBlock, *syncedBlock)
+	s.Equal(uint64(10), *syncedBlock)
 }
 
 func (s *BlockNumberTestSuite) TestGetSyncedBlock_NoExistentChainState() {
@@ -57,11 +57,8 @@ func (s *BlockNumberTestSuite) TestGetSyncedBlock_NoExistentChainState() {
 }
 
 func (s *BlockNumberTestSuite) TestSetSyncedBlock() {
-	err := s.storage.SetChainState(&chainState)
-	s.NoError(err)
-
 	blockNumber := uint64(450)
-	err = s.storage.SetSyncedBlock(blockNumber)
+	err := s.storage.SetSyncedBlock(blockNumber)
 	s.NoError(err)
 
 	syncedBlock, err := s.storage.GetSyncedBlock()

--- a/storage/chain_state_test.go
+++ b/storage/chain_state_test.go
@@ -18,7 +18,6 @@ var (
 		DepositManager:                 utils.RandomAddress(),
 		WithdrawManager:                utils.RandomAddress(),
 		Rollup:                         utils.RandomAddress(),
-		SyncedBlock:                    10,
 	}
 )
 


### PR DESCRIPTION
While syncing, every time we process a new block we update the
SyncedBlock record. When a row is updated in Badger the entire row is
written to disk. Previously, this meant that every time we injested a
new block we wrote a copy of the entire ChainState record to disk. This
caused massive write amplification for deployments with a large genesis.
SyncedBlock is now stored separately, eliminating the worst of the write
amplification.