### PR TITLE
Remove --atomic from helm deployment for prod

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -270,6 +270,6 @@ jobs:
           --name ${{ secrets.AWS_PROD_CLUSTER }}
       - name: Helm install
         run: helm upgrade "${{ github.event.repository.name }}" ./deploy/hubble
-          --install --atomic --timeout 120s
+          --install
           --namespace "${{ github.event.repository.name }}"
           --set image.tag="${{ github.sha }}"


### PR DESCRIPTION
Hubble can take a while to startup, lets remove waiting done via --atomic.