### PR TITLE
Misc production fixes, add more tracing

### DIFF
--- a/api/get_transaction_test.go
+++ b/api/get_transaction_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/bls"
@@ -104,7 +105,7 @@ func (s *GetTransactionTestSuite) TearDownTest() {
 }
 
 func (s *GetTransactionTestSuite) TestGetTransaction_Transfer() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.NoError(err)
 
 	receipt, err := s.api.GetTransaction(*hash)
@@ -115,7 +116,7 @@ func (s *GetTransactionTestSuite) TestGetTransaction_Transfer() {
 }
 
 func (s *GetTransactionTestSuite) TestGetTransaction_Create2Transfer() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.create2Transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.create2Transfer))
 	s.NoError(err)
 
 	receipt, err := s.api.GetTransaction(*hash)
@@ -126,7 +127,7 @@ func (s *GetTransactionTestSuite) TestGetTransaction_Create2Transfer() {
 }
 
 func (s *GetTransactionTestSuite) TestGetTransaction_MassMigration() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.massMigration))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.massMigration))
 	s.NoError(err)
 
 	receipt, err := s.api.GetTransaction(*hash)

--- a/api/get_user_state.go
+++ b/api/get_user_state.go
@@ -17,7 +17,7 @@ var getUserStateAPIErrors = map[error]*APIError{
 
 func (a *API) GetUserState(ctx context.Context, id uint32) (*dto.UserStateWithID, error) {
 	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(attribute.Int64("stateID", int64(id)))
+	span.SetAttributes(attribute.Int64("hubble.stateID", int64(id)))
 
 	log.WithFields(o11y.TraceFields(ctx)).Infof("Getting state for id: %d", id)
 

--- a/api/get_user_states.go
+++ b/api/get_user_states.go
@@ -27,13 +27,13 @@ func (a *API) GetUserStates(ctx context.Context, publicKey *models.PublicKey) ([
 
 func (a *API) unsafeGetUserStates(ctx context.Context, publicKey *models.PublicKey) ([]dto.UserStateWithID, error) {
 	span := trace.SpanFromContext(ctx)
-	span.SetAttributes(attribute.String("publicKey", publicKey.String()))
+	span.SetAttributes(attribute.String("hubble.publicKey", publicKey.String()))
 
 	log.WithFields(o11y.TraceFields(ctx)).Infof("Getting leaves for public key: %s", publicKey.String())
 
 	leaves, err := a.storage.GetStateLeavesByPublicKey(publicKey)
 	if err != nil {
-		span.SetAttributes(attribute.String("error", err.Error()))
+		span.SetAttributes(attribute.String("hubble.error", err.Error()))
 		log.WithFields(o11y.TraceFields(ctx)).Errorf("Error getting leaves by public key: %v", err)
 		return nil, err
 	}

--- a/api/handle_create2transfer.go
+++ b/api/handle_create2transfer.go
@@ -23,12 +23,12 @@ func (a *API) handleCreate2Transfer(ctx context.Context, create2TransferDTO dto.
 
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
-		attribute.String("tx.type", "create2Transfer"),
-		attribute.Int64("tx.fromStateID", int64(create2Transfer.FromStateID)),
-		attribute.String("tx.toPublicKey", create2Transfer.ToPublicKey.String()),
-		attribute.String("tx.amount", create2Transfer.Amount.String()),
-		attribute.String("tx.fee", create2Transfer.Fee.String()),
-		attribute.Int64("tx.nonce", int64(create2Transfer.Nonce.Uint64())),
+		attribute.String("hubble.tx.type", "create2Transfer"),
+		attribute.Int64("hubble.tx.fromStateID", int64(create2Transfer.FromStateID)),
+		attribute.String("hubble.tx.toPublicKey", create2Transfer.ToPublicKey.String()),
+		attribute.String("hubble.tx.amount", create2Transfer.Amount.String()),
+		attribute.String("hubble.tx.fee", create2Transfer.Fee.String()),
+		attribute.Int64("hubble.tx.nonce", int64(create2Transfer.Nonce.Uint64())),
 	)
 
 	if vErr := a.validateCreate2Transfer(create2Transfer); vErr != nil {

--- a/api/handle_create2transfer.go
+++ b/api/handle_create2transfer.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"errors"
 
 	"github.com/Worldcoin/hubble-commander/encoder"
@@ -9,14 +10,26 @@ import (
 	"github.com/Worldcoin/hubble-commander/models/enums/txtype"
 	"github.com/ethereum/go-ethereum/common"
 	bh "github.com/timshannon/badgerhold/v4"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
-func (a *API) handleCreate2Transfer(create2TransferDTO dto.Create2Transfer) (*common.Hash, error) {
+func (a *API) handleCreate2Transfer(ctx context.Context, create2TransferDTO dto.Create2Transfer) (*common.Hash, error) {
 	create2Transfer, err := sanitizeCreate2Transfer(create2TransferDTO)
 	if err != nil {
 		a.countRejectedTx(txtype.Create2Transfer)
 		return nil, err
 	}
+
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.String("txType", "create2Transfer"),
+		attribute.Int64("fromStateID", int64(create2Transfer.FromStateID)),
+		attribute.String("toPublicKey", create2Transfer.ToPublicKey.String()),
+		attribute.String("amount", create2Transfer.Amount.String()),
+		attribute.String("fee", create2Transfer.Fee.String()),
+		attribute.Int64("nonce", int64(create2Transfer.Nonce.Uint64())),
+	)
 
 	if vErr := a.validateCreate2Transfer(create2Transfer); vErr != nil {
 		a.countRejectedTx(txtype.Create2Transfer)

--- a/api/handle_create2transfer.go
+++ b/api/handle_create2transfer.go
@@ -23,12 +23,12 @@ func (a *API) handleCreate2Transfer(ctx context.Context, create2TransferDTO dto.
 
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
-		attribute.String("txType", "create2Transfer"),
-		attribute.Int64("fromStateID", int64(create2Transfer.FromStateID)),
-		attribute.String("toPublicKey", create2Transfer.ToPublicKey.String()),
-		attribute.String("amount", create2Transfer.Amount.String()),
-		attribute.String("fee", create2Transfer.Fee.String()),
-		attribute.Int64("nonce", int64(create2Transfer.Nonce.Uint64())),
+		attribute.String("tx.type", "create2Transfer"),
+		attribute.Int64("tx.fromStateID", int64(create2Transfer.FromStateID)),
+		attribute.String("tx.toPublicKey", create2Transfer.ToPublicKey.String()),
+		attribute.String("tx.amount", create2Transfer.Amount.String()),
+		attribute.String("tx.fee", create2Transfer.Fee.String()),
+		attribute.Int64("tx.nonce", int64(create2Transfer.Nonce.Uint64())),
 	)
 
 	if vErr := a.validateCreate2Transfer(create2Transfer); vErr != nil {

--- a/api/handle_create2transfer_test.go
+++ b/api/handle_create2transfer_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/bls"
@@ -95,7 +96,7 @@ func (s *SendCreate2TransferTestSuite) TearDownTest() {
 }
 
 func (s *SendCreate2TransferTestSuite) TestSendTransaction_ReturnsNonNilHash() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.create2Transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.create2Transfer))
 	s.NoError(err)
 	s.NotNil(hash)
 }
@@ -107,7 +108,7 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_ValidatesNonceTooLow_
 	_, err := s.storage.StateTree.Set(1, userStateWithIncreasedNonce)
 	s.NoError(err)
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(s.create2Transfer))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.create2Transfer))
 	s.Equal(APIErrNonceTooLow, err)
 }
 
@@ -115,7 +116,7 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_ValidatesFeeValue() {
 	transferWithZeroFee := s.create2Transfer
 	transferWithZeroFee.Fee = models.NewUint256(0)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithZeroFee))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithZeroFee))
 	s.Equal(APIErrFeeTooLow, err)
 }
 
@@ -123,7 +124,7 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_ValidatesFeeEncodabil
 	transferWithBadFee := s.create2Transfer
 	transferWithBadFee.Fee = models.NewUint256(66666666)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithBadFee))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithBadFee))
 	s.Equal(APINotDecimalEncodableFeeError, err)
 }
 
@@ -131,7 +132,7 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_ValidatesAmountEncoda
 	transferWithBadAmount := s.create2Transfer
 	transferWithBadAmount.Amount = models.NewUint256(66666666)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithBadAmount))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithBadAmount))
 	s.Equal(APINotDecimalEncodableAmountError, err)
 }
 
@@ -139,7 +140,7 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_ValidatesAmountValue(
 	transferWithZeroAmount := s.create2Transfer
 	transferWithZeroAmount.Amount = models.NewUint256(0)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithZeroAmount))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithZeroAmount))
 	s.Equal(APIErrInvalidAmount, err)
 }
 
@@ -147,7 +148,7 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_ValidatesBalance() {
 	transferWithHugeAmount := s.create2Transfer
 	transferWithHugeAmount.Amount = models.NewUint256(500)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithHugeAmount))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithHugeAmount))
 	s.Equal(APIErrNotEnoughBalance, err)
 }
 
@@ -160,7 +161,7 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_ValidatesSignature() 
 	transfer := create2TransferWithoutSignature
 	transfer.Signature = fakeSignature.ModelsSignature()
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(transfer))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(transfer))
 	s.Equal(APIErrInvalidSignature, err)
 }
 
@@ -175,12 +176,12 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_ValidatesSignature_Di
 	transfer := create2TransferWithoutSignature
 	transfer.Signature = fakeSignature.ModelsSignature()
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(transfer))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(transfer))
 	s.NoError(err)
 }
 
 func (s *SendCreate2TransferTestSuite) TestSendTransaction_AddsTransferToStorage() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.create2Transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.create2Transfer))
 	s.NoError(err)
 	s.NotNil(hash)
 
@@ -190,7 +191,7 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_AddsTransferToStorage
 }
 
 func (s *SendCreate2TransferTestSuite) TestSendTransaction_UpdatesFailedTransaction() {
-	originalHash, err := s.api.SendTransaction(dto.MakeTransaction(s.create2Transfer))
+	originalHash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.create2Transfer))
 	s.NoError(err)
 
 	err = s.storage.SetTransactionErrors(models.TxError{
@@ -202,7 +203,7 @@ func (s *SendCreate2TransferTestSuite) TestSendTransaction_UpdatesFailedTransact
 	originalTx, err := s.storage.GetCreate2Transfer(*originalHash)
 	s.NoError(err)
 
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.create2Transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.create2Transfer))
 	s.NoError(err)
 	s.Equal(*originalHash, *hash)
 

--- a/api/handle_mass_migration_test.go
+++ b/api/handle_mass_migration_test.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/bls"
@@ -96,7 +97,7 @@ func (s *SendMassMigrationTestSuite) TearDownTest() {
 }
 
 func (s *SendMassMigrationTestSuite) TestSendTransaction_ReturnsNonNilHash() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.massMigration))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.massMigration))
 	s.NoError(err)
 	s.NotNil(hash)
 }
@@ -108,7 +109,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_ValidatesNonceTooLow_No
 	_, err := s.storage.StateTree.Set(1, userStateWithIncreasedNonce)
 	s.NoError(err)
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(s.massMigration))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.massMigration))
 	s.Equal(APIErrNonceTooLow, err)
 }
 
@@ -116,7 +117,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_ValidatesFeeValue() {
 	massMigrationWithZeroFee := s.massMigration
 	massMigrationWithZeroFee.Fee = models.NewUint256(0)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(massMigrationWithZeroFee))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(massMigrationWithZeroFee))
 	s.Equal(APIErrFeeTooLow, err)
 }
 
@@ -124,7 +125,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_ValidatesFeeEncodabilit
 	massMigrationWithBadFee := s.massMigration
 	massMigrationWithBadFee.Fee = models.NewUint256(66666666)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(massMigrationWithBadFee))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(massMigrationWithBadFee))
 	s.Equal(APINotDecimalEncodableFeeError, err)
 }
 
@@ -132,7 +133,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_ValidatesAmountEncodabi
 	massMigrationWithBadAmount := s.massMigration
 	massMigrationWithBadAmount.Amount = models.NewUint256(66666666)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(massMigrationWithBadAmount))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(massMigrationWithBadAmount))
 	s.Equal(APINotDecimalEncodableAmountError, err)
 }
 
@@ -140,7 +141,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_ValidatesThatSpokeExist
 	massMigrationWithNonexistentSpoke := s.massMigration
 	massMigrationWithNonexistentSpoke.SpokeID = ref.Uint32(1)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(massMigrationWithNonexistentSpoke))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(massMigrationWithNonexistentSpoke))
 	s.Equal(APIErrSpokeDoesNotExist, err)
 }
 
@@ -148,7 +149,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_ValidatesAmountValue() 
 	massMigrationWithZeroAmount := s.massMigration
 	massMigrationWithZeroAmount.Amount = models.NewUint256(0)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(massMigrationWithZeroAmount))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(massMigrationWithZeroAmount))
 	s.Equal(APIErrInvalidAmount, err)
 }
 
@@ -156,7 +157,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_ValidatesBalance() {
 	massMigrationWithHugeAmount := s.massMigration
 	massMigrationWithHugeAmount.Amount = models.NewUint256(500)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(massMigrationWithHugeAmount))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(massMigrationWithHugeAmount))
 	s.Equal(APIErrNotEnoughBalance, err)
 }
 
@@ -169,7 +170,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_ValidatesSignature() {
 	massMigration := massMigrationWithoutSignature
 	massMigration.Signature = fakeSignature.ModelsSignature()
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(massMigration))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(massMigration))
 	s.Equal(APIErrInvalidSignature, err)
 }
 
@@ -184,12 +185,12 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_ValidatesSignature_Disa
 	massMigration := massMigrationWithoutSignature
 	massMigration.Signature = fakeSignature.ModelsSignature()
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(massMigration))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(massMigration))
 	s.NoError(err)
 }
 
 func (s *SendMassMigrationTestSuite) TestSendTransaction_AddsMassMigrationToStorage() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.massMigration))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.massMigration))
 	s.NoError(err)
 	s.NotNil(hash)
 
@@ -199,7 +200,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_AddsMassMigrationToStor
 }
 
 func (s *SendMassMigrationTestSuite) TestSendTransaction_UpdatesFailedTransaction() {
-	originalHash, err := s.api.SendTransaction(dto.MakeTransaction(s.massMigration))
+	originalHash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.massMigration))
 	s.NoError(err)
 
 	err = s.storage.SetTransactionErrors(models.TxError{
@@ -211,7 +212,7 @@ func (s *SendMassMigrationTestSuite) TestSendTransaction_UpdatesFailedTransactio
 	originalTx, err := s.storage.GetMassMigration(*originalHash)
 	s.NoError(err)
 
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.massMigration))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.massMigration))
 	s.NoError(err)
 	s.Equal(*originalHash, *hash)
 

--- a/api/handle_transfer.go
+++ b/api/handle_transfer.go
@@ -24,12 +24,12 @@ func (a *API) handleTransfer(ctx context.Context, transferDTO dto.Transfer) (*co
 
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
-		attribute.String("txType", "transfer"),
-		attribute.Int64("fromStateID", int64(transfer.FromStateID)),
-		attribute.Int64("toStateID", int64(transfer.ToStateID)),
-		attribute.String("amount", transfer.Amount.String()),
-		attribute.String("fee", transfer.Fee.String()),
-		attribute.Int64("nonce", int64(transfer.Nonce.Uint64())),
+		attribute.String("tx.type", "transfer"),
+		attribute.Int64("tx.fromStateID", int64(transfer.FromStateID)),
+		attribute.Int64("tx.toStateID", int64(transfer.ToStateID)),
+		attribute.String("tx.amount", transfer.Amount.String()),
+		attribute.String("tx.fee", transfer.Fee.String()),
+		attribute.Int64("tx.nonce", int64(transfer.Nonce.Uint64())),
 	)
 
 	if vErr := a.validateTransfer(transfer); vErr != nil {

--- a/api/handle_transfer.go
+++ b/api/handle_transfer.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"context"
+
 	"github.com/Worldcoin/hubble-commander/encoder"
 	"github.com/Worldcoin/hubble-commander/models"
 	"github.com/Worldcoin/hubble-commander/models/dto"
@@ -9,14 +11,26 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/pkg/errors"
 	bh "github.com/timshannon/badgerhold/v4"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
 )
 
-func (a *API) handleTransfer(transferDTO dto.Transfer) (*common.Hash, error) {
+func (a *API) handleTransfer(ctx context.Context, transferDTO dto.Transfer) (*common.Hash, error) {
 	transfer, err := sanitizeTransfer(transferDTO)
 	if err != nil {
 		a.countRejectedTx(txtype.Transfer)
 		return nil, err
 	}
+
+	span := trace.SpanFromContext(ctx)
+	span.SetAttributes(
+		attribute.String("txType", "transfer"),
+		attribute.Int64("fromStateID", int64(transfer.FromStateID)),
+		attribute.Int64("toStateID", int64(transfer.ToStateID)),
+		attribute.String("amount", transfer.Amount.String()),
+		attribute.String("fee", transfer.Fee.String()),
+		attribute.Int64("nonce", int64(transfer.Nonce.Uint64())),
+	)
 
 	if vErr := a.validateTransfer(transfer); vErr != nil {
 		a.countRejectedTx(txtype.Transfer)

--- a/api/handle_transfer.go
+++ b/api/handle_transfer.go
@@ -24,12 +24,12 @@ func (a *API) handleTransfer(ctx context.Context, transferDTO dto.Transfer) (*co
 
 	span := trace.SpanFromContext(ctx)
 	span.SetAttributes(
-		attribute.String("tx.type", "transfer"),
-		attribute.Int64("tx.fromStateID", int64(transfer.FromStateID)),
-		attribute.Int64("tx.toStateID", int64(transfer.ToStateID)),
-		attribute.String("tx.amount", transfer.Amount.String()),
-		attribute.String("tx.fee", transfer.Fee.String()),
-		attribute.Int64("tx.nonce", int64(transfer.Nonce.Uint64())),
+		attribute.String("hubble.tx.type", "transfer"),
+		attribute.Int64("hubble.tx.fromStateID", int64(transfer.FromStateID)),
+		attribute.Int64("hubble.tx.toStateID", int64(transfer.ToStateID)),
+		attribute.String("hubble.tx.amount", transfer.Amount.String()),
+		attribute.String("hubble.tx.fee", transfer.Fee.String()),
+		attribute.Int64("hubble.tx.nonce", int64(transfer.Nonce.Uint64())),
 	)
 
 	if vErr := a.validateTransfer(transfer); vErr != nil {

--- a/api/handle_transfer_test.go
+++ b/api/handle_transfer_test.go
@@ -126,7 +126,7 @@ func (s *SendTransferTestSuite) TearDownTest() {
 }
 
 func (s *SendTransferTestSuite) TestSendTransaction_ReturnsNonNilHash() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.NoError(err)
 	s.NotNil(hash)
 }
@@ -138,7 +138,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_ValidatesNonceTooLow_NoTrans
 	_, err := s.storage.StateTree.Set(1, userStateWithIncreasedNonce)
 	s.NoError(err)
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.Equal(APIErrNonceTooLow, err)
 }
 
@@ -146,7 +146,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_ValidatesFeeValue() {
 	transferWithZeroFee := s.transfer
 	transferWithZeroFee.Fee = models.NewUint256(0)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithZeroFee))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithZeroFee))
 	s.Equal(APIErrFeeTooLow, err)
 }
 
@@ -154,7 +154,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_ValidatesFeeEncodability() {
 	transferWithBadFee := s.transfer
 	transferWithBadFee.Fee = models.NewUint256(66666666)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithBadFee))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithBadFee))
 	s.Equal(APINotDecimalEncodableFeeError, err)
 }
 
@@ -162,7 +162,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_ValidatesAmountEncodability(
 	transferWithBadAmount := s.transfer
 	transferWithBadAmount.Amount = models.NewUint256(66666666)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithBadAmount))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithBadAmount))
 	s.Equal(APINotDecimalEncodableAmountError, err)
 }
 
@@ -170,7 +170,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_ValidatesAmountValue() {
 	transferWithZeroAmount := s.transfer
 	transferWithZeroAmount.Amount = models.NewUint256(0)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithZeroAmount))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithZeroAmount))
 	s.Equal(APIErrInvalidAmount, err)
 }
 
@@ -178,7 +178,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_ValidatesBalance() {
 	transferWithHugeAmount := s.transfer
 	transferWithHugeAmount.Amount = models.NewUint256(500)
 
-	_, err := s.api.SendTransaction(dto.MakeTransaction(transferWithHugeAmount))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(transferWithHugeAmount))
 	s.Equal(APIErrNotEnoughBalance, err)
 }
 
@@ -191,7 +191,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_ValidatesSignature() {
 	transfer := transferWithoutSignature
 	transfer.Signature = fakeSignature.ModelsSignature()
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(transfer))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(transfer))
 	s.Equal(APIErrInvalidSignature, err)
 }
 
@@ -206,12 +206,12 @@ func (s *SendTransferTestSuite) TestSendTransaction_ValidatesSignature_DisabledS
 	transfer := transferWithoutSignature
 	transfer.Signature = fakeSignature.ModelsSignature()
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(transfer))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(transfer))
 	s.NoError(err)
 }
 
 func (s *SendTransferTestSuite) TestSendTransaction_AddsTransferToStorage() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.NoError(err)
 	s.NotNil(hash)
 
@@ -221,7 +221,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_AddsTransferToStorage() {
 }
 
 func (s *SendTransferTestSuite) TestSendTransaction_UpdatesFailedTransaction() {
-	originalHash, err := s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	originalHash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.NoError(err)
 
 	err = s.storage.SetTransactionErrors(models.TxError{
@@ -233,7 +233,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_UpdatesFailedTransaction() {
 	originalTx, err := s.storage.GetTransfer(*originalHash)
 	s.NoError(err)
 
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.NoError(err)
 	s.Equal(*originalHash, *hash)
 
@@ -244,15 +244,15 @@ func (s *SendTransferTestSuite) TestSendTransaction_UpdatesFailedTransaction() {
 }
 
 func (s *SendTransferTestSuite) TestSendTransaction_DoesNotUpdatePendingTransfer() {
-	_, err := s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.NoError(err)
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.Equal(APIErrPendingTransaction, err)
 }
 
 func (s *SendTransferTestSuite) TestSendTransaction_DoesNotUpdateMinedTransfer() {
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.NoError(err)
 
 	tx, err := s.storage.GetTransfer(*hash)
@@ -261,13 +261,13 @@ func (s *SendTransferTestSuite) TestSendTransaction_DoesNotUpdateMinedTransfer()
 	err = s.storage.MarkTransfersAsIncluded([]models.Transfer{*tx}, &models.CommitmentID{BatchID: models.MakeUint256(1)})
 	s.NoError(err)
 
-	_, err = s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	_, err = s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.Equal(APIErrMinedTransaction, err)
 }
 
 func (s *SendTransferTestSuite) TestSendTransaction_DoesNotAcceptTransactions() {
 	s.api.isAcceptingTransactions = false
-	_, err := s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	_, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.Equal(APIErrSendTxMethodDisabled, err)
 }
 
@@ -279,7 +279,7 @@ func (s *SendTransferTestSuite) TestSendTransaction_SendsTxToTxPool() {
 	wg := &sync.WaitGroup{}
 	ctx, cancel := context.WithCancel(context.Background())
 
-	hash, err := s.api.SendTransaction(dto.MakeTransaction(s.transfer))
+	hash, err := s.api.SendTransaction(context.Background(), dto.MakeTransaction(s.transfer))
 	s.NoError(err)
 
 	wg.Add(1)

--- a/api/middleware/opentelemetry.go
+++ b/api/middleware/opentelemetry.go
@@ -63,7 +63,7 @@ func OpenTelemetryHandler(next http.Handler) http.Handler {
 		if response.Error != nil {
 			span.RecordError(response.Error)
 			span.SetStatus(codes.Error, response.Error.Error())
-			span.SetAttributes(attribute.Int("errorCode", response.Error.Code))
+			span.SetAttributes(attribute.Int("hubble.errorCode", response.Error.Code))
 		} else {
 			span.SetStatus(codes.Ok, "")
 		}

--- a/api/send_transaction.go
+++ b/api/send_transaction.go
@@ -119,7 +119,7 @@ func (a *API) unsafeSendTransaction(ctx context.Context, tx dto.Transaction) (*c
 	case dto.Transfer:
 		return a.handleTransfer(ctx, t)
 	case dto.Create2Transfer:
-		return a.handleCreate2Transfer(t)
+		return a.handleCreate2Transfer(ctx, t)
 	case dto.MassMigration:
 		return a.handleMassMigration(t)
 	default:

--- a/api/send_transaction.go
+++ b/api/send_transaction.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Worldcoin/hubble-commander/bls"
@@ -100,12 +101,12 @@ var sendTransactionAPIErrors = map[error]*APIError{
 	ErrSendTxMethodDisabled:               APIErrSendTxMethodDisabled,
 }
 
-func (a *API) SendTransaction(tx dto.Transaction) (*common.Hash, error) {
+func (a *API) SendTransaction(ctx context.Context, tx dto.Transaction) (*common.Hash, error) {
 	if !a.isAcceptingTransactions {
 		return nil, sanitizeError(ErrSendTxMethodDisabled, sendTransactionAPIErrors)
 	}
 
-	transactionHash, err := a.unsafeSendTransaction(tx)
+	transactionHash, err := a.unsafeSendTransaction(ctx, tx)
 	if err != nil {
 		return nil, sanitizeError(err, sendTransactionAPIErrors)
 	}
@@ -113,10 +114,10 @@ func (a *API) SendTransaction(tx dto.Transaction) (*common.Hash, error) {
 	return transactionHash, nil
 }
 
-func (a *API) unsafeSendTransaction(tx dto.Transaction) (*common.Hash, error) {
+func (a *API) unsafeSendTransaction(ctx context.Context, tx dto.Transaction) (*common.Hash, error) {
 	switch t := tx.Parsed.(type) {
 	case dto.Transfer:
-		return a.handleTransfer(t)
+		return a.handleTransfer(ctx, t)
 	case dto.Create2Transfer:
 		return a.handleCreate2Transfer(t)
 	case dto.MassMigration:

--- a/commander/accounts.go
+++ b/commander/accounts.go
@@ -112,7 +112,10 @@ func (c *Commander) syncBatchAccounts(ctx context.Context, start, end uint64) (n
 	return newAccountsCount, it.Error()
 }
 
-func (c *Commander) syncBatchAccountsTx(ctx context.Context, event *accountregistry.AccountRegistryBatchPubkeyRegistered) (newAccountsCount int, err error) {
+func (c *Commander) syncBatchAccountsTx(
+	ctx context.Context,
+	event *accountregistry.AccountRegistryBatchPubkeyRegistered,
+) (newAccountsCount int, err error) {
 	_, span := newBlockTracer.Start(ctx, "syncBatchAccountsTx")
 	defer span.End()
 

--- a/commander/accounts.go
+++ b/commander/accounts.go
@@ -25,7 +25,7 @@ func (c *Commander) syncAccounts(ctx context.Context, start, end uint64) error {
 	var newAccountsSingle *int
 	var newAccountsBatch *int
 
-	_, span := rollupTracer.Start(ctx, "syncAccounts")
+	_, span := newBlockTracer.Start(ctx, "syncAccounts")
 	defer span.End()
 
 	duration, err := metrics.MeasureDuration(func() (err error) {

--- a/commander/accounts.go
+++ b/commander/accounts.go
@@ -15,6 +15,8 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 var ErrAccountLeavesInconsistency = fmt.Errorf("inconsistency in account leaves between the database and the contract")
@@ -25,7 +27,7 @@ func (c *Commander) syncAccounts(ctx context.Context, start, end uint64) error {
 	var newAccountsSingle *int
 	var newAccountsBatch *int
 
-	_, span := newBlockTracer.Start(ctx, "syncAccounts")
+	spanCtx, span := newBlockTracer.Start(ctx, "syncAccounts")
 	defer span.End()
 
 	duration, err := metrics.MeasureDuration(func() (err error) {
@@ -33,7 +35,7 @@ func (c *Commander) syncAccounts(ctx context.Context, start, end uint64) error {
 		if err != nil {
 			return err
 		}
-		newAccountsBatch, err = c.syncBatchAccounts(start, end)
+		newAccountsBatch, err = c.syncBatchAccounts(spanCtx, start, end)
 		if err != nil {
 			return err
 		}
@@ -90,7 +92,7 @@ func (c *Commander) syncSingleAccounts(start, end uint64) (newAccountsCount *int
 	return newAccountsCount, it.Error()
 }
 
-func (c *Commander) syncBatchAccounts(start, end uint64) (newAccountsCount *int, err error) {
+func (c *Commander) syncBatchAccounts(ctx context.Context, start, end uint64) (newAccountsCount *int, err error) {
 	it, err := c.getBatchPubKeyRegisteredIterator(start, end)
 	if err != nil {
 		return nil, err
@@ -100,30 +102,66 @@ func (c *Commander) syncBatchAccounts(start, end uint64) (newAccountsCount *int,
 	newAccountsCount = ref.Int(0)
 
 	for it.Next() {
-		tx, _, err := c.client.Blockchain.GetBackend().TransactionByHash(context.Background(), it.Event.Raw.TxHash)
+		count, err := c.syncBatchAccountsTx(ctx, it.Event)
 		if err != nil {
 			return nil, err
 		}
-
-		if !bytes.Equal(tx.Data()[:4], c.client.AccountRegistry.ABI.Methods["registerBatch"].ID) {
-			continue // TODO handle internal transactions
-		}
-
-		accounts, err := c.client.ExtractAccountsBatch(tx.Data(), it.Event)
-		if err != nil {
-			return nil, err
-		}
-
-		isNewAccount, err := saveSyncedBatchAccounts(c.storage.AccountTree, accounts)
-		if err != nil {
-			return nil, err
-		}
-		if *isNewAccount {
-			*newAccountsCount += len(accounts)
-		}
+		*newAccountsCount += count
 	}
 
 	return newAccountsCount, it.Error()
+}
+
+func (c *Commander) syncBatchAccountsTx(ctx context.Context, event *accountregistry.AccountRegistryBatchPubkeyRegistered) (newAccountsCount int, err error) {
+	_, span := newBlockTracer.Start(ctx, "syncBatchAccountsTx")
+	defer span.End()
+
+	tx, _, err := c.client.Blockchain.GetBackend().TransactionByHash(context.Background(), event.Raw.TxHash)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return 0, err
+	}
+
+	span.SetAttributes(
+		attribute.String("hubble.ethTx.hash", tx.Hash().String()),
+		attribute.Int64("hubble.ethTx.nonce", int64(tx.Nonce())),
+	)
+
+	if !bytes.Equal(tx.Data()[:4], c.client.AccountRegistry.ABI.Methods["registerBatch"].ID) {
+		// so we can alert if any of these appear
+		span.SetAttributes(
+			attribute.Bool("hubble.wasInternalTx", true),
+		)
+		span.SetStatus(codes.Error, "unhandled: internal account")
+		return 0, nil // TODO handle internal transactions
+	}
+
+	accounts, err := c.client.ExtractAccountsBatch(tx.Data(), event)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return 0, err
+	}
+
+	span.SetAttributes(
+		attribute.Int("hubble.accountCount", len(accounts)),
+	)
+
+	isNewAccount, err := saveSyncedBatchAccounts(c.storage.AccountTree, accounts)
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+		return 0, err
+	}
+
+	span.SetStatus(codes.Ok, "")
+
+	if *isNewAccount {
+		return len(accounts), nil
+	} else {
+		return 0, nil
+	}
 }
 
 func (c *Commander) getSinglePubKeyRegisteredIterator(start, end uint64) (*accountregistry.SinglePubKeyRegisteredIterator, error) {

--- a/commander/accounts_test.go
+++ b/commander/accounts_test.go
@@ -76,7 +76,7 @@ func (s *AccountsTestSuite) TestSyncBatchAccounts() {
 
 	latestBlockNumber, err := s.testClient.GetLatestBlockNumber()
 	s.NoError(err)
-	newAccountsCount, err := s.cmd.syncBatchAccounts(0, *latestBlockNumber)
+	newAccountsCount, err := s.cmd.syncBatchAccounts(context.Background(), 0, *latestBlockNumber)
 	s.NoError(err)
 	s.Equal(ref.Int(st.AccountBatchSize), newAccountsCount)
 

--- a/commander/batches.go
+++ b/commander/batches.go
@@ -66,11 +66,14 @@ func (c *Commander) unsafeSyncBatches(ctx context.Context, startBlock, endBlock 
 		return true
 	}
 
-	newRemoteBatches, err := c.client.GetBatches(&eth.BatchesFilters{
-		StartBlockInclusive: startBlock,
-		EndBlockInclusive:   &endBlock,
-		FilterByBatchID:     filter,
-	})
+	newRemoteBatches, err := c.client.GetBatches(
+		ctx,
+		&eth.BatchesFilters{
+			StartBlockInclusive: startBlock,
+			EndBlockInclusive:   &endBlock,
+			FilterByBatchID:     filter,
+		},
+	)
 	if err != nil {
 		return err
 	}

--- a/commander/batches.go
+++ b/commander/batches.go
@@ -13,19 +13,20 @@ import (
 	st "github.com/Worldcoin/hubble-commander/storage"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 var ErrSyncedFraudulentBatch = errors.New("commander synced fraudulent batch")
 
 func (c *Commander) syncBatches(ctx context.Context, startBlock, endBlock uint64) error {
-	_, span := newBlockTracer.Start(ctx, "syncBatches")
+	spanCtx, span := newBlockTracer.Start(ctx, "syncBatches")
 	defer span.End()
 
 	c.stateMutex.Lock()
 	defer c.stateMutex.Unlock()
 
 	duration, err := metrics.MeasureDuration(func() error {
-		return c.unsafeSyncBatches(startBlock, endBlock)
+		return c.unsafeSyncBatches(spanCtx, startBlock, endBlock)
 	})
 	if err != nil {
 		return err
@@ -38,7 +39,7 @@ func (c *Commander) syncBatches(ctx context.Context, startBlock, endBlock uint64
 	return nil
 }
 
-func (c *Commander) unsafeSyncBatches(startBlock, endBlock uint64) error {
+func (c *Commander) unsafeSyncBatches(ctx context.Context, startBlock, endBlock uint64) error {
 	err := c.txPool.UpdateMempool()
 	if err != nil {
 		return err
@@ -75,7 +76,7 @@ func (c *Commander) unsafeSyncBatches(startBlock, endBlock uint64) error {
 	}
 
 	for _, remoteBatch := range newRemoteBatches {
-		err = c.syncRemoteBatch(remoteBatch)
+		err = c.syncRemoteBatch(ctx, remoteBatch)
 		if err != nil {
 			return err
 		}
@@ -95,8 +96,18 @@ func (c *Commander) unsafeSyncBatches(startBlock, endBlock uint64) error {
 	return nil
 }
 
-func (c *Commander) syncRemoteBatch(remoteBatch eth.DecodedBatch) error {
+func (c *Commander) syncRemoteBatch(ctx context.Context, remoteBatch eth.DecodedBatch) error {
 	var icError *syncer.InconsistentBatchError
+
+	_, span := newBlockTracer.Start(ctx, "syncRemoteBatch")
+	defer span.End()
+
+	span.SetAttributes(
+		attribute.Int64("hubble.batchID", int64(remoteBatch.GetBase().ID.Uint64())),
+		attribute.String("hubble.batchType", remoteBatch.GetBase().Type.String()),
+		attribute.String("hubble.batchHash", remoteBatch.GetBase().Hash.String()),
+		attribute.Int("hubble.commitmentCount", remoteBatch.GetCommitmentsLength()),
+	)
 
 	err := c.syncOrDisputeRemoteBatch(remoteBatch)
 	if errors.As(err, &icError) {

--- a/commander/batches.go
+++ b/commander/batches.go
@@ -18,7 +18,7 @@ import (
 var ErrSyncedFraudulentBatch = errors.New("commander synced fraudulent batch")
 
 func (c *Commander) syncBatches(ctx context.Context, startBlock, endBlock uint64) error {
-	_, span := rollupTracer.Start(ctx, "syncBatches")
+	_, span := newBlockTracer.Start(ctx, "syncBatches")
 	defer span.End()
 
 	c.stateMutex.Lock()

--- a/commander/deposit_batches_test.go
+++ b/commander/deposit_batches_test.go
@@ -169,7 +169,7 @@ func (s *DepositBatchesTestSuite) submitDepositBatch(storage *st.Storage) *model
 	)
 	defer depositsCtx.Rollback(nil)
 
-	batch, _, err := depositsCtx.CreateAndSubmitBatch()
+	batch, _, err := depositsCtx.CreateAndSubmitBatch(context.Background())
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()

--- a/commander/deposit_batches_test.go
+++ b/commander/deposit_batches_test.go
@@ -91,7 +91,7 @@ func (s *DepositBatchesTestSuite) TestSyncRemoteBatch_SyncsDepositBatch() {
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.NoError(err)
 
 	batches, err := s.storage.GetBatchesInRange(nil, nil)
@@ -111,7 +111,7 @@ func (s *DepositBatchesTestSuite) TestUnsafeSyncBatches_OmitsRolledBackBatch() {
 	s.NoError(err)
 
 	// trigger dispute on fraudulent batch
-	err = s.cmd.unsafeSyncBatches(0, *latestBlock)
+	err = s.cmd.unsafeSyncBatches(context.Background(), 0, *latestBlock)
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	depositBatch := s.submitDepositBatch(s.storage.Storage)
@@ -119,7 +119,7 @@ func (s *DepositBatchesTestSuite) TestUnsafeSyncBatches_OmitsRolledBackBatch() {
 	s.NoError(err)
 
 	// try syncing already rolled back batch
-	err = s.cmd.unsafeSyncBatches(0, *latestBlock)
+	err = s.cmd.unsafeSyncBatches(context.Background(), 0, *latestBlock)
 	s.NoError(err)
 
 	batches, err := s.storage.GetBatchesInRange(nil, nil)

--- a/commander/deposits.go
+++ b/commander/deposits.go
@@ -15,7 +15,7 @@ import (
 func (c *Commander) syncDeposits(ctx context.Context, start, end uint64) error {
 	var depositSubtrees []models.PendingDepositSubtree
 
-	_, span := rollupTracer.Start(ctx, "syncDeposits")
+	_, span := newBlockTracer.Start(ctx, "syncDeposits")
 	defer span.End()
 
 	duration, err := metrics.MeasureDuration(func() error {

--- a/commander/disputer/context_test_suite.go
+++ b/commander/disputer/context_test_suite.go
@@ -1,6 +1,8 @@
 package disputer
 
 import (
+	"context"
+
 	"github.com/Worldcoin/hubble-commander/bls"
 	"github.com/Worldcoin/hubble-commander/commander/executor"
 	"github.com/Worldcoin/hubble-commander/commander/syncer"
@@ -139,7 +141,7 @@ func (s *testSuiteWithContexts) rollback() {
 func (s *testSuiteWithContexts) submitBatch(tx models.GenericTransaction) *models.Batch {
 	s.addTxs(models.MakeGenericArray(tx))
 
-	pendingBatch, _, err := s.txsCtx.CreateAndSubmitBatch()
+	pendingBatch, _, err := s.txsCtx.CreateAndSubmitBatch(context.Background())
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()

--- a/commander/disputer/dispute_transition_test_suite.go
+++ b/commander/disputer/dispute_transition_test_suite.go
@@ -1,6 +1,7 @@
 package disputer
 
 import (
+	"context"
 	"fmt"
 
 	"github.com/Worldcoin/hubble-commander/commander/syncer"
@@ -50,12 +51,12 @@ func (s *disputeTransitionTestSuite) submitInvalidBatch(txs models.GenericTransa
 	s.NoError(err)
 	fmt.Println(*pendingBatch.PrevStateRoot)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 
 	commitments[len(commitments)-1].ToCommitment().GetCommitmentBase().PostStateRoot = common.Hash{1, 2, 3}
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, commitments)
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()

--- a/commander/executor/create_batch.go
+++ b/commander/executor/create_batch.go
@@ -1,24 +1,32 @@
 package executor
 
 import (
+	"context"
+
 	"github.com/Worldcoin/hubble-commander/models"
 	"github.com/Worldcoin/hubble-commander/models/enums/batchtype"
 	"github.com/Worldcoin/hubble-commander/utils/ref"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel"
 )
 
-func (c *TxsContext) CreateAndSubmitBatch() (*models.Batch, *int, error) {
+func (c *TxsContext) CreateAndSubmitBatch(ctx context.Context) (*models.Batch, *int, error) {
+	spanCtx, span := otel.Tracer("txsContext").Start(ctx, "CreateAndSubmitBatch")
+	defer span.End()
+
 	batch, err := c.NewPendingBatch(c.BatchType)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	commitments, err := c.CreateCommitments()
+	// this is where we register the pending accounts
+	commitments, err := c.CreateCommitments(spanCtx)
 	if err != nil {
 		return nil, nil, err
 	}
 
-	err = c.SubmitBatch(batch, commitments)
+	// this is where we actually submit!
+	err = c.SubmitBatch(spanCtx, batch, commitments)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/commander/executor/create_c2t_commitments_test.go
+++ b/commander/executor/create_c2t_commitments_test.go
@@ -37,7 +37,7 @@ func (s *C2TCommitmentsTestSuite) TestCreateCommitments_UpdatesTransactions() {
 	transfers := testutils.GenerateValidCreate2Transfers(2)
 	s.initTxs(transfers)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 
@@ -55,7 +55,7 @@ func (s *C2TCommitmentsTestSuite) TestCreateCommitments_RegistersAccounts() {
 	s.initTxs(transfers)
 
 	expectedTxsLength := encoder.Create2TransferLength * len(transfers)
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 	s.Len(commitments[0].ToTxCommitmentWithTxs().Transactions, expectedTxsLength)
@@ -75,7 +75,7 @@ func (s *C2TCommitmentsTestSuite) TestRegisterPendingAccounts_RegistersAccountsA
 		}
 	}
 
-	err := s.txsCtx.registerPendingAccounts(pendingAccounts)
+	err := s.txsCtx.registerPendingAccounts(context.Background(), pendingAccounts)
 	s.NoError(err)
 	s.client.GetBackend().Commit()
 
@@ -105,7 +105,7 @@ func (s *C2TCommitmentsTestSuite) TestRegisterPendingAccounts_FillsMissingAccoun
 		},
 	}
 
-	err := s.txsCtx.registerPendingAccounts(pendingAccounts)
+	err := s.txsCtx.registerPendingAccounts(context.Background(), pendingAccounts)
 	s.NoError(err)
 	s.client.GetBackend().Commit()
 

--- a/commander/executor/create_commitments_test.go
+++ b/commander/executor/create_commitments_test.go
@@ -82,7 +82,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_WithMinTxsPerCommitme
 	s.NoError(err)
 
 	expectedTxsLength := encoder.TransferLength * len(transfers)
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 	s.Len(commitments[0].ToTxCommitmentWithTxs().Transactions, expectedTxsLength)
@@ -100,7 +100,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_WithMoreThanMinTxsPer
 	s.NoError(err)
 
 	expectedTxsLength := encoder.TransferLength * len(transfers)
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 	s.Len(commitments[0].ToTxCommitmentWithTxs().Transactions, expectedTxsLength)
@@ -136,7 +136,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_ForMultipleCommitment
 	preRoot, err := s.txsCtx.storage.StateTree.Root()
 	s.NoError(err)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 3)
 	s.Len(commitments[0].ToTxCommitmentWithTxs().Transactions, s.maxTxBytesInCommitment)
@@ -162,7 +162,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_ReturnsErrorWhenThere
 
 	s.preparePendingTransfers(0)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.Nil(commitments)
 	s.ErrorIs(err, ErrNotEnoughTxs)
 
@@ -184,7 +184,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_ReturnsErrorWhenThere
 
 	s.preparePendingTransfers(2)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.Nil(commitments)
 	s.ErrorIs(err, ErrNotEnoughTxs)
 }
@@ -197,7 +197,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_StoresCorrectCommitme
 	s.NoError(err)
 
 	expectedTxsLength := encoder.TransferLength * int(transfersCount)
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 	s.Len(commitments[0].ToTxCommitmentWithTxs().Transactions, expectedTxsLength)
@@ -212,7 +212,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_StoresCorrectCommitme
 func (s *CreateCommitmentsTestSuite) TestCreateCommitments_CreatesMaximallyAsManyCommitmentsAsSpecifiedInConfig() {
 	s.preparePendingTransfers(5)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 }
@@ -220,7 +220,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_CreatesMaximallyAsMan
 func (s *CreateCommitmentsTestSuite) TestCreateCommitments_MarksTransfersAsIncludedInCommitment() {
 	transfers := s.preparePendingTransfers(4)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 
@@ -240,7 +240,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_SkipsNonceTooHighTx()
 
 	s.initTxs(validTxs.AppendOne(nonceTooHighTx))
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 
@@ -268,7 +268,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_DoesNotCreateCommitme
 	invalidTransfer := testutils.MakeTransfer(2, 1, 1234, 100)
 	s.initTxs(models.TransferArray{validTransfer, invalidTransfer})
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.Nil(commitments)
 	s.ErrorIs(err, ErrNotEnoughTxs)
 }
@@ -287,7 +287,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_ReadyTransactionSkips
 	}
 	s.initTxs(models.TransferArray{validTransfer})
 
-	batchData, err := s.txsCtx.CreateCommitments()
+	batchData, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.NotNil(batchData)
 }
@@ -302,7 +302,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_ReturnsErrorIfCouldNo
 	invalidTransfer := testutils.MakeTransfer(2, 1, 1234, 100)
 	s.initTxs(models.TransferArray{validTransfer, invalidTransfer})
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.Nil(commitments)
 	s.ErrorIs(err, ErrNotEnoughTxs)
 }
@@ -314,7 +314,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_StoresErrorMessagesOf
 	invalidTransfer := testutils.MakeTransfer(1, 1234, 0, 100)
 	s.initTxs(models.TransferArray{invalidTransfer})
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.Nil(commitments)
 	s.ErrorIs(err, ErrNotEnoughTxs)
 	s.Len(s.txsCtx.txErrorsToStore, 1)
@@ -335,7 +335,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_DoesNotCallRevertToWh
 	preStateRoot, err := s.storage.StateTree.Root()
 	s.NoError(err)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.Nil(commitments)
 	s.ErrorIs(err, ErrNotEnoughTxs)
 
@@ -369,7 +369,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_CallsRevertToWhenNece
 	)
 	initTxs(s.Assertions, tempTxsCtx, validTransfers[:2])
 
-	commitments, err := tempTxsCtx.CreateCommitments()
+	commitments, err := tempTxsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 
@@ -386,7 +386,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_CallsRevertToWhenNece
 
 	s.initTxs(validTransfers.AppendOne(&invalidTransfer))
 
-	commitments, err = s.txsCtx.CreateCommitments()
+	commitments, err = s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 
@@ -407,7 +407,7 @@ func (s *CreateCommitmentsTestSuite) TestCreateCommitments_SupportsTransactionRe
 
 	s.initTxs(models.TransferArray{transfer, higherFeeTransfer})
 
-	_, err := s.txsCtx.CreateCommitments()
+	_, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 
 	minedHigherFeeTransfer, err := s.storage.GetTransfer(higherFeeTransfer.Hash)

--- a/commander/executor/create_mm_commitments_test.go
+++ b/commander/executor/create_mm_commitments_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/config"
@@ -43,7 +44,7 @@ func (s *MMCommitmentsTestSuite) TestCreateCommitments_ReturnsCorrectMetaAndWith
 
 	withdrawRoot := s.generateWithdrawRoot(massMigrations)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 	s.Len(commitments, 1)

--- a/commander/executor/deposits.go
+++ b/commander/executor/deposits.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"context"
+
 	"github.com/Worldcoin/hubble-commander/models"
 	"github.com/Worldcoin/hubble-commander/models/enums/batchtype"
 	st "github.com/Worldcoin/hubble-commander/storage"
@@ -10,7 +12,7 @@ import (
 
 var ErrNotEnoughDeposits = NewRollupError("not enough deposits")
 
-func (c *DepositsContext) CreateAndSubmitBatch() (*models.Batch, *int, error) {
+func (c *DepositsContext) CreateAndSubmitBatch(ctx context.Context) (*models.Batch, *int, error) {
 	batch, err := c.NewPendingBatch(batchtype.Deposit)
 	if err != nil {
 		return nil, nil, err

--- a/commander/executor/revert_batches_test.go
+++ b/commander/executor/revert_batches_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/config"
@@ -129,7 +130,7 @@ func (s *RevertBatchesTestSuite) addTxBatch(tx *models.Transfer) *models.Batch {
 	pendingBatch, err := s.txsCtx.NewPendingBatch(s.txsCtx.BatchType)
 	s.NoError(err)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 
 	err = s.storage.AddBatch(pendingBatch)

--- a/commander/executor/rollup_loop_context.go
+++ b/commander/executor/rollup_loop_context.go
@@ -13,7 +13,7 @@ import (
 )
 
 type RollupLoopContext interface {
-	CreateAndSubmitBatch() (*models.Batch, *int, error)
+	CreateAndSubmitBatch(ctx context.Context) (*models.Batch, *int, error)
 	ExecutePendingBatch(batch *models.PendingBatch) error
 	Rollback(cause *error)
 	Commit() error

--- a/commander/executor/submit_batch.go
+++ b/commander/executor/submit_batch.go
@@ -1,19 +1,25 @@
 package executor
 
 import (
+	"context"
+
 	"github.com/Worldcoin/hubble-commander/models"
+	"go.opentelemetry.io/otel"
 )
 
 var ErrRollupContextCanceled = NewLoggableRollupError("rollup context canceled")
 
-func (c *TxsContext) SubmitBatch(batch *models.Batch, commitments []models.CommitmentWithTxs) error {
+func (c *TxsContext) SubmitBatch(ctx context.Context, batch *models.Batch, commitments []models.CommitmentWithTxs) error {
+	spanCtx, span := otel.Tracer("txsContext").Start(ctx, "SubmitBatch")
+	defer span.End()
+
 	select {
 	case <-c.ctx.Done():
 		return ErrRollupContextCanceled
 	default:
 	}
 
-	tx, err := c.Executor.SubmitBatch(&batch.ID, commitments)
+	tx, err := c.Executor.SubmitBatch(spanCtx, &batch.ID, commitments)
 	if err != nil {
 		return err
 	}

--- a/commander/executor/submit_c2t_batch_test.go
+++ b/commander/executor/submit_c2t_batch_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
@@ -30,7 +31,7 @@ func (s *SubmitC2TBatchTestSuite) TestSubmitBatch_SubmitsCommitmentsOnChain() {
 	commitment := s.baseCommitment
 	commitment.ID.BatchID = pendingBatch.ID
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, []models.CommitmentWithTxs{&commitment})
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, []models.CommitmentWithTxs{&commitment})
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()
@@ -47,7 +48,7 @@ func (s *SubmitC2TBatchTestSuite) TestSubmitBatch_StoresPendingBatchRecord() {
 	commitment := s.baseCommitment
 	commitment.ID.BatchID = pendingBatch.ID
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, []models.CommitmentWithTxs{&commitment})
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, []models.CommitmentWithTxs{&commitment})
 	s.NoError(err)
 
 	batch, err := s.storage.GetBatch(models.MakeUint256(1))
@@ -64,7 +65,7 @@ func (s *SubmitC2TBatchTestSuite) TestSubmitBatch_AddsCommitments() {
 	s.NoError(err)
 	commitments := getTxCommitments(2, pendingBatch.ID, batchtype.Create2Transfer)
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, commitments)
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	batch, err := s.storage.GetBatch(models.MakeUint256(1))

--- a/commander/executor/submit_mm_batch_test.go
+++ b/commander/executor/submit_mm_batch_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
@@ -47,7 +48,7 @@ func (s *SubmitMassMigrationBatchTestSuite) TestSubmitBatch_SubmitsCommitmentsOn
 
 	s.commitment.ID.BatchID = pendingBatch.ID
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, []models.CommitmentWithTxs{s.commitment})
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, []models.CommitmentWithTxs{s.commitment})
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()
@@ -63,7 +64,7 @@ func (s *SubmitMassMigrationBatchTestSuite) TestSubmitBatch_StoresPendingBatchRe
 
 	s.commitment.ID.BatchID = pendingBatch.ID
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, []models.CommitmentWithTxs{s.commitment})
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, []models.CommitmentWithTxs{s.commitment})
 	s.NoError(err)
 
 	batch, err := s.storage.GetBatch(models.MakeUint256(1))
@@ -81,7 +82,7 @@ func (s *SubmitMassMigrationBatchTestSuite) TestSubmitBatch_AddsCommitments() {
 
 	commitments := getMMCommitments(2, pendingBatch.ID)
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, commitments)
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	batch, err := s.storage.GetBatch(models.MakeUint256(1))

--- a/commander/executor/submit_transfer_batch_test.go
+++ b/commander/executor/submit_transfer_batch_test.go
@@ -1,6 +1,7 @@
 package executor
 
 import (
+	"context"
 	"math/big"
 	"testing"
 
@@ -26,7 +27,7 @@ func (s *SubmitTransferBatchTestSuite) TestSubmitBatch_SubmitsCommitmentsOnChain
 	commitment := baseCommitment
 	commitment.ID.BatchID = pendingBatch.ID
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, []models.CommitmentWithTxs{&commitment})
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, []models.CommitmentWithTxs{&commitment})
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()
@@ -43,7 +44,7 @@ func (s *SubmitTransferBatchTestSuite) TestSubmitBatch_StoresPendingBatchRecord(
 	commitment := baseCommitment
 	commitment.ID.BatchID = pendingBatch.ID
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, []models.CommitmentWithTxs{&commitment})
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, []models.CommitmentWithTxs{&commitment})
 	s.NoError(err)
 
 	batch, err := s.storage.GetBatch(models.MakeUint256(1))
@@ -60,7 +61,7 @@ func (s *SubmitTransferBatchTestSuite) TestSubmitBatch_AddsCommitments() {
 	s.NoError(err)
 	commitments := getTxCommitments(2, pendingBatch.ID, batchtype.Transfer)
 
-	err = s.txsCtx.SubmitBatch(pendingBatch, commitments)
+	err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	batch, err := s.storage.GetBatch(models.MakeUint256(1))

--- a/commander/executor/transaction_executor.go
+++ b/commander/executor/transaction_executor.go
@@ -98,7 +98,11 @@ func (e *TransferExecutor) ApplyTx(tx models.GenericTransaction, commitmentToken
 	return e.applier.ApplyTransfer(tx, commitmentTokenID)
 }
 
-func (e *TransferExecutor) SubmitBatch(ctx context.Context, batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error) {
+func (e *TransferExecutor) SubmitBatch(
+	ctx context.Context,
+	batchID *models.Uint256,
+	commitments []models.CommitmentWithTxs,
+) (*types.Transaction, error) {
 	return e.client.SubmitTransfersBatch(batchID, commitments)
 }
 
@@ -193,7 +197,11 @@ func (e *C2TExecutor) ApplyTx(tx models.GenericTransaction, commitmentTokenID mo
 	return e.applier.ApplyCreate2Transfer(tx.ToCreate2Transfer(), commitmentTokenID)
 }
 
-func (e *C2TExecutor) SubmitBatch(ctx context.Context, batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error) {
+func (e *C2TExecutor) SubmitBatch(
+	ctx context.Context,
+	batchID *models.Uint256,
+	commitments []models.CommitmentWithTxs,
+) (*types.Transaction, error) {
 	return e.client.SubmitCreate2TransfersBatch(ctx, batchID, commitments)
 }
 
@@ -281,7 +289,7 @@ func (e *MassMigrationExecutor) ApplyTx(tx models.GenericTransaction, commitment
 }
 
 func (e *MassMigrationExecutor) SubmitBatch(
-	context context.Context,
+	ctx context.Context,
 	batchID *models.Uint256,
 	commitments []models.CommitmentWithTxs,
 ) (*types.Transaction, error) {

--- a/commander/executor/transaction_executor.go
+++ b/commander/executor/transaction_executor.go
@@ -1,6 +1,8 @@
 package executor
 
 import (
+	"context"
+
 	"github.com/Worldcoin/hubble-commander/commander/applier"
 	"github.com/Worldcoin/hubble-commander/encoder"
 	"github.com/Worldcoin/hubble-commander/eth"
@@ -20,7 +22,7 @@ type TransactionExecutor interface {
 	AddPendingAccount(result applier.ApplySingleTxResult) error
 	NewCreateCommitmentResult(result ExecuteTxsForCommitmentResult, commitment models.CommitmentWithTxs) CreateCommitmentResult
 	ApplyTx(tx models.GenericTransaction, commitmentTokenID models.Uint256) (result applier.ApplySingleTxResult, txError, appError error)
-	SubmitBatch(batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error)
+	SubmitBatch(ctx context.Context, batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error)
 	GenerateMetaAndWithdrawRoots(commitment models.CommitmentWithTxs, result CreateCommitmentResult) error
 	NewCommitment(
 		commitmentID *models.CommitmentID,
@@ -96,7 +98,7 @@ func (e *TransferExecutor) ApplyTx(tx models.GenericTransaction, commitmentToken
 	return e.applier.ApplyTransfer(tx, commitmentTokenID)
 }
 
-func (e *TransferExecutor) SubmitBatch(batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error) {
+func (e *TransferExecutor) SubmitBatch(ctx context.Context, batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error) {
 	return e.client.SubmitTransfersBatch(batchID, commitments)
 }
 
@@ -191,8 +193,8 @@ func (e *C2TExecutor) ApplyTx(tx models.GenericTransaction, commitmentTokenID mo
 	return e.applier.ApplyCreate2Transfer(tx.ToCreate2Transfer(), commitmentTokenID)
 }
 
-func (e *C2TExecutor) SubmitBatch(batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error) {
-	return e.client.SubmitCreate2TransfersBatch(batchID, commitments)
+func (e *C2TExecutor) SubmitBatch(ctx context.Context, batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error) {
+	return e.client.SubmitCreate2TransfersBatch(ctx, batchID, commitments)
 }
 
 func (e *C2TExecutor) GenerateMetaAndWithdrawRoots(_ models.CommitmentWithTxs, _ CreateCommitmentResult) error {
@@ -279,6 +281,7 @@ func (e *MassMigrationExecutor) ApplyTx(tx models.GenericTransaction, commitment
 }
 
 func (e *MassMigrationExecutor) SubmitBatch(
+	context context.Context,
 	batchID *models.Uint256,
 	commitments []models.CommitmentWithTxs,
 ) (*types.Transaction, error) {

--- a/commander/mm_batches_test.go
+++ b/commander/mm_batches_test.go
@@ -69,7 +69,7 @@ func (s *MMBatchesTestSuite) TestSyncRemoteBatch_SyncsBatch() {
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.NoError(err)
 
 	batches, err := s.storage.GetBatchesInRange(nil, nil)
@@ -92,7 +92,7 @@ func (s *MMBatchesTestSuite) TestSyncRemoteBatch_DisputesBatchWithMismatchedTota
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -110,7 +110,7 @@ func (s *MMBatchesTestSuite) TestSyncRemoteBatch_DisputesBatchWithInvalidWithdra
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -128,7 +128,7 @@ func (s *MMBatchesTestSuite) TestSyncRemoteBatch_DisputesBatchWithInvalidTokenID
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())

--- a/commander/mm_batches_test.go
+++ b/commander/mm_batches_test.go
@@ -149,13 +149,13 @@ func (s *MMBatchesTestSuite) submitInvalidBatch(tx *models.MassMigration, modifi
 	pendingBatch, err := txsCtx.NewPendingBatch(txsCtx.BatchType)
 	s.NoError(err)
 
-	commitments, err := txsCtx.CreateCommitments()
+	commitments, err := txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 
 	modifier(commitments)
 
-	err = txsCtx.SubmitBatch(pendingBatch, commitments)
+	err = txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()
@@ -176,7 +176,7 @@ func (s *MMBatchesTestSuite) submitBatch(storage *st.Storage) *models.Batch {
 	)
 	defer txsCtx.Rollback(nil)
 
-	batch, _, err := txsCtx.CreateAndSubmitBatch()
+	batch, _, err := txsCtx.CreateAndSubmitBatch(context.Background())
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()

--- a/commander/new_block.go
+++ b/commander/new_block.go
@@ -216,8 +216,8 @@ func (c *Commander) syncRange(startBlock, endBlock uint64) error {
 	ctx, span := newBlockTracer.Start(context.Background(), "syncRange")
 	defer span.End()
 	span.SetAttributes(
-		attribute.Int("startBlock", int(startBlock)),
-		attribute.Int("endBlock", int(endBlock)),
+		attribute.Int("hubble.startBlock", int(startBlock)),
+		attribute.Int("hubble.endBlock", int(endBlock)),
 	)
 
 	err := c.syncAccounts(ctx, startBlock, endBlock)

--- a/commander/new_block.go
+++ b/commander/new_block.go
@@ -12,12 +12,15 @@ import (
 	"github.com/pkg/errors"
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 )
 
 var (
 	ErrIncompleteBlockRangeSync = stdErrors.New("syncing of a block range was stopped prematurely")
 	ErrRollbackInProgress       = stdErrors.New("rollback is in progress")
+
+	newBlockTracer = otel.Tracer("newBlockLoop")
 )
 
 func (c *Commander) newBlockLoop() error {
@@ -210,7 +213,7 @@ func (c *Commander) syncForward(latestBlockNumber uint64) (*uint64, error) {
 func (c *Commander) syncRange(startBlock, endBlock uint64) error {
 	logSyncedBlocks(startBlock, endBlock)
 
-	ctx, span := rollupTracer.Start(context.Background(), "syncRange")
+	ctx, span := newBlockTracer.Start(context.Background(), "syncRange")
 	defer span.End()
 	span.SetAttributes(
 		attribute.Int("startBlock", int(startBlock)),

--- a/commander/new_block_test.go
+++ b/commander/new_block_test.go
@@ -1,6 +1,7 @@
 package commander
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -167,13 +168,13 @@ func (s *NewBlockLoopTestSuite) submitTransferBatchInTransaction(tx *models.Tran
 		_, err = txsCtx.Mempool.AddOrReplace(txStorage, tx)
 		s.NoError(err)
 
-		commitments, err := txsCtx.CreateCommitments()
+		commitments, err := txsCtx.CreateCommitments(context.Background())
 		s.NoError(err)
 		s.Len(commitments, 1)
 
 		batch, err := txsCtx.NewPendingBatch(batchtype.Transfer)
 		s.NoError(err)
-		err = txsCtx.SubmitBatch(batch, commitments)
+		err = txsCtx.SubmitBatch(context.Background(), batch, commitments)
 		s.NoError(err)
 		s.client.GetBackend().Commit()
 	})

--- a/commander/registered_spokes.go
+++ b/commander/registered_spokes.go
@@ -17,7 +17,7 @@ import (
 )
 
 func (c *Commander) syncSpokes(ctx context.Context, startBlock, endBlock uint64) error {
-	_, span := rollupTracer.Start(ctx, "syncSpokes")
+	_, span := newBlockTracer.Start(ctx, "syncSpokes")
 	defer span.End()
 
 	duration, err := metrics.MeasureDuration(func() error {

--- a/commander/registered_tokens.go
+++ b/commander/registered_tokens.go
@@ -19,7 +19,7 @@ import (
 func (c *Commander) syncTokens(ctx context.Context, startBlock, endBlock uint64) error {
 	var newTokensCount *int
 
-	_, span := rollupTracer.Start(ctx, "syncTokens")
+	_, span := newBlockTracer.Start(ctx, "syncTokens")
 	defer span.End()
 
 	duration, err := metrics.MeasureDuration(func() (err error) {

--- a/commander/rollup.go
+++ b/commander/rollup.go
@@ -92,7 +92,7 @@ func (c *Commander) unsafeRollupLoopIteration(ctx context.Context, currentBatchT
 
 	rollupCtx := executor.NewRollupLoopContext(c.storage, c.client, c.cfg.Rollup, c.metrics, c.txPool.Mempool(), spanCtx, *currentBatchType)
 	defer rollupCtx.Rollback(&err)
-	span.SetAttributes(attribute.String("batchType", currentBatchType.String()))
+	span.SetAttributes(attribute.String("hubble.batchType", currentBatchType.String()))
 
 	// this chooses the type of the next batch, currentBatchType is not read once
 	// the rollupCtx has been created.
@@ -111,6 +111,7 @@ func (c *Commander) unsafeRollupLoopIteration(ctx context.Context, currentBatchT
 		// this requires custom configuration of the dd agent:
 		//  apm_config.filter_tags.reject = ["manual.drop:true"]
 		// if we don't do this then ~ every 500µs we emit a new trace
+		// https://docs.datadoghq.com/tracing/guide/ignoring_apm_resources/?tab=datadogyaml#ignoring-based-on-span-tags
 		span.SetAttributes(attribute.Bool("manual.drop", true))
 	}
 

--- a/commander/rollup.go
+++ b/commander/rollup.go
@@ -92,9 +92,11 @@ func (c *Commander) unsafeRollupLoopIteration(ctx context.Context, currentBatchT
 
 	rollupCtx := executor.NewRollupLoopContext(c.storage, c.client, c.cfg.Rollup, c.metrics, c.txPool.Mempool(), spanCtx, *currentBatchType)
 	defer rollupCtx.Rollback(&err)
-
-	switchBatchType(currentBatchType)
 	span.SetAttributes(attribute.String("batchType", currentBatchType.String()))
+
+	// this chooses the type of the next batch, currentBatchType is not read once
+	// the rollupCtx has been created.
+	switchBatchType(currentBatchType)
 
 	var (
 		batch            *models.Batch

--- a/commander/rollup.go
+++ b/commander/rollup.go
@@ -118,7 +118,6 @@ func (c *Commander) unsafeRollupLoopIteration(ctx context.Context, currentBatchT
 		"type": metrics.BatchTypeToMetricsBatchType(batch.Type),
 	})
 
-	// time.Sleep(20*time.Second)
 	logNewBatch(batch, *commitmentsCount, duration)
 
 	err = func() error {

--- a/commander/stake_withdrawals.go
+++ b/commander/stake_withdrawals.go
@@ -13,7 +13,7 @@ import (
 )
 
 func (c *Commander) syncStakeWithdrawals(ctx context.Context, startBlock, endBlock uint64) error {
-	_, span := rollupTracer.Start(ctx, "syncStakeWithdrawls")
+	_, span := newBlockTracer.Start(ctx, "syncStakeWithdrawls")
 	defer span.End()
 
 	duration, err := metrics.MeasureDuration(func() (err error) {

--- a/commander/sync_stake_withdrawals_test.go
+++ b/commander/sync_stake_withdrawals_test.go
@@ -1,6 +1,7 @@
 package commander
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -120,13 +121,13 @@ func (s *SyncStakeWithdrawalsTestSuite) submitTransferBatchInTransaction(tx *mod
 		_, err = txsCtx.Mempool.AddOrReplace(txStorage, tx)
 		s.NoError(err)
 
-		batchData, err := txsCtx.CreateCommitments()
+		batchData, err := txsCtx.CreateCommitments(context.Background())
 		s.NoError(err)
 		s.Len(batchData, 1)
 
 		batch, err := txsCtx.NewPendingBatch(batchtype.Transfer)
 		s.NoError(err)
-		err = txsCtx.SubmitBatch(batch, batchData)
+		err = txsCtx.SubmitBatch(context.Background(), batch, batchData)
 		s.NoError(err)
 		s.client.GetBackend().Commit()
 	})

--- a/commander/syncer/deposits_sync_test.go
+++ b/commander/syncer/deposits_sync_test.go
@@ -59,7 +59,7 @@ func (s *SyncDepositBatchTestSuite) TearDownTest() {
 }
 
 func (s *SyncDepositBatchTestSuite) TestSyncBatch_SingleBatch() {
-	_, _, err := s.depositsCtx.CreateAndSubmitBatch()
+	_, _, err := s.depositsCtx.CreateAndSubmitBatch(context.Background())
 	s.NoError(err)
 	s.client.GetBackend().Commit()
 	s.depositsCtx.Rollback(nil)
@@ -86,7 +86,7 @@ func (s *SyncDepositBatchTestSuite) TestSyncBatch_SingleBatch() {
 }
 
 func (s *SyncDepositBatchTestSuite) TestSyncBatch_SetsUserStates() {
-	_, _, err := s.depositsCtx.CreateAndSubmitBatch()
+	_, _, err := s.depositsCtx.CreateAndSubmitBatch(context.Background())
 	s.NoError(err)
 	s.client.GetBackend().Commit()
 	s.depositsCtx.Rollback(nil)
@@ -107,7 +107,7 @@ func (s *SyncDepositBatchTestSuite) TestSyncBatch_SetsUserStates() {
 }
 
 func (s *SyncDepositBatchTestSuite) TestSyncBatch_SyncsExistingBatch() {
-	_, _, err := s.depositsCtx.CreateAndSubmitBatch()
+	_, _, err := s.depositsCtx.CreateAndSubmitBatch(context.Background())
 	s.NoError(err)
 	s.client.GetBackend().Commit()
 	err = s.depositsCtx.Commit()

--- a/commander/syncer/sync_test_suite.go
+++ b/commander/syncer/sync_test_suite.go
@@ -1,6 +1,8 @@
 package syncer
 
 import (
+	"context"
+
 	"github.com/Worldcoin/hubble-commander/bls"
 	"github.com/Worldcoin/hubble-commander/commander/executor"
 	"github.com/Worldcoin/hubble-commander/config"
@@ -140,7 +142,7 @@ func (s *syncTestSuite) getAccountTreeRoot() common.Hash {
 func (s *syncTestSuite) submitBatch(tx models.GenericTransaction) []models.CommitmentWithTxs {
 	pendingBatch, commitments := s.createBatch(tx)
 
-	err := s.txsCtx.SubmitBatch(pendingBatch, commitments)
+	err := s.txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()
@@ -153,7 +155,7 @@ func (s *syncTestSuite) createBatch(tx models.GenericTransaction) (*models.Batch
 	pendingBatch, err := s.txsCtx.NewPendingBatch(s.txsCtx.BatchType)
 	s.NoError(err)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 

--- a/commander/syncer/txs_sync_c2t_batch_test.go
+++ b/commander/syncer/txs_sync_c2t_batch_test.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/encoder"
@@ -62,7 +63,7 @@ func (s *SyncC2TBatchTestSuite) TestSyncBatch_InvalidCommitmentStateRoot() {
 	batch, commitments := s.createBatch(&tx2)
 	commitments[0].ToTxCommitmentWithTxs().PostStateRoot = utils.RandomHash()
 
-	err := s.txsCtx.SubmitBatch(batch, commitments)
+	err := s.txsCtx.SubmitBatch(context.Background(), batch, commitments)
 	s.NoError(err)
 	s.client.GetBackend().Commit()
 
@@ -186,7 +187,7 @@ func (s *SyncC2TBatchTestSuite) submitInvalidBatch(tx *models.Create2Transfer) {
 	commitment := commitments[0].ToTxCommitmentWithTxs()
 	commitment.Transactions = bytes.Repeat(commitment.Transactions, 2)
 
-	err := s.txsCtx.SubmitBatch(pendingBatch, commitments)
+	err := s.txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()

--- a/commander/syncer/txs_sync_mm_batch_test.go
+++ b/commander/syncer/txs_sync_mm_batch_test.go
@@ -1,6 +1,7 @@
 package syncer
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/encoder"
@@ -125,7 +126,7 @@ func (s *SyncMMBatchTestSuite) submitInvalidBatch(tx models.GenericTransaction, 
 
 	modifier(commitments)
 
-	err := s.txsCtx.SubmitBatch(pendingBatch, commitments)
+	err := s.txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()

--- a/commander/syncer/txs_sync_transfer_batch_test.go
+++ b/commander/syncer/txs_sync_transfer_batch_test.go
@@ -2,6 +2,7 @@ package syncer
 
 import (
 	"bytes"
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/commander/executor"
@@ -53,7 +54,7 @@ func (s *SyncTransferBatchTestSuite) TestSyncBatch_TwoBatches() {
 		s.addTx(txs[i])
 	}
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 2)
 	accountRoots := make([]common.Hash, len(commitments))
@@ -65,7 +66,7 @@ func (s *SyncTransferBatchTestSuite) TestSyncBatch_TwoBatches() {
 		commitments[i].ToTxCommitmentWithTxs().ID.BatchID = pendingBatch.ID
 		commitments[i].ToTxCommitmentWithTxs().ID.IndexInBatch = 0
 
-		err = s.txsCtx.SubmitBatch(pendingBatch, []models.CommitmentWithTxs{commitments[i]})
+		err = s.txsCtx.SubmitBatch(context.Background(), pendingBatch, []models.CommitmentWithTxs{commitments[i]})
 		s.NoError(err)
 		s.client.GetBackend().Commit()
 
@@ -166,7 +167,7 @@ func (s *SyncTransferBatchTestSuite) TestSyncBatch_InvalidCommitmentStateRoot() 
 	batch, commitments := s.createBatch(&tx2)
 	commitments[0].ToTxCommitmentWithTxs().PostStateRoot = utils.RandomHash()
 
-	err := s.txsCtx.SubmitBatch(batch, commitments)
+	err := s.txsCtx.SubmitBatch(context.Background(), batch, commitments)
 	s.NoError(err)
 	s.client.GetBackend().Commit()
 
@@ -219,7 +220,7 @@ func (s *SyncTransferBatchTestSuite) TestSyncBatch_NotValidBLSSignature() {
 	pendingBatch, commitments := s.createBatch(&tx)
 	commitments[0].ToTxCommitmentWithTxs().CombinedSignature = models.Signature{1, 2, 3}
 
-	err := s.txsCtx.SubmitBatch(pendingBatch, commitments)
+	err := s.txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 	s.client.GetBackend().Commit()
 
@@ -303,7 +304,7 @@ func (s *SyncTransferBatchTestSuite) TestSyncBatch_AddsSyncedTxsAsBatched() {
 		s.NoError(err)
 	}
 
-	pendingBatch, _, err := s.txsCtx.CreateAndSubmitBatch()
+	pendingBatch, _, err := s.txsCtx.CreateAndSubmitBatch(context.Background())
 	s.NoError(err)
 	s.client.Backend.Commit()
 
@@ -378,7 +379,7 @@ func (s *SyncTransferBatchTestSuite) submitInvalidBatch(tx *models.Transfer) *mo
 	commitment := commitments[0].ToTxCommitmentWithTxs()
 	commitments[0].ToTxCommitmentWithTxs().Transactions = bytes.Repeat(commitment.Transactions, 2)
 
-	err := s.txsCtx.SubmitBatch(pendingBatch, commitments)
+	err := s.txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	s.client.GetBackend().Commit()

--- a/commander/txs_batches_test.go
+++ b/commander/txs_batches_test.go
@@ -1,6 +1,7 @@
 package commander
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/bls"
@@ -496,7 +497,7 @@ func (s *TxsBatchesTestSuite) createTransferBatchLocally(tx *models.Transfer) *m
 	pendingBatch, err := s.txsCtx.NewPendingBatch(batchtype.Transfer)
 	s.NoError(err)
 
-	commitments, err := s.txsCtx.CreateCommitments()
+	commitments, err := s.txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 	err = s.cmd.storage.AddCommitment(commitments[0].ToCommitment())
@@ -564,13 +565,13 @@ func submitInvalidTxsBatch(
 	pendingBatch, err := txsCtx.NewPendingBatch(txsCtx.BatchType)
 	s.NoError(err)
 
-	commitments, err := txsCtx.CreateCommitments()
+	commitments, err := txsCtx.CreateCommitments(context.Background())
 	s.NoError(err)
 	s.Len(commitments, 1)
 
 	modifier(storage, commitments[0].ToTxCommitmentWithTxs())
 
-	err = txsCtx.SubmitBatch(pendingBatch, commitments)
+	err = txsCtx.SubmitBatch(context.Background(), pendingBatch, commitments)
 	s.NoError(err)
 
 	return pendingBatch

--- a/commander/txs_batches_test.go
+++ b/commander/txs_batches_test.go
@@ -122,7 +122,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_ReplaceLocalBatchWithRemoteOne
 	s.Len(batches, 1)
 	remoteBatch := batches[0]
 
-	err = s.cmd.syncRemoteBatch(remoteBatch)
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatch)
 	s.NoError(err)
 
 	// Correct batch stored
@@ -176,7 +176,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesBatchWithTooManyTxs() 
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -193,7 +193,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesBatchWithInvalidPostSt
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -211,7 +211,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesFraudulentBatchWithSel
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -232,7 +232,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesCommitmentWithInvalidS
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -251,7 +251,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesCommitmentWithSignatur
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -272,7 +272,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_RemovesExistingBatchAndDispute
 	s.Len(remoteBatches, 1)
 	remoteBatch := remoteBatches[0]
 
-	err = s.cmd.syncRemoteBatch(remoteBatch)
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatch)
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatch.GetID())
@@ -292,7 +292,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesFraudulentCommitmentAf
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -309,7 +309,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesCommitmentWithInvalidF
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -326,7 +326,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesCommitmentWithoutTrans
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -346,7 +346,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesCommitmentWithNonexist
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -390,7 +390,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesC2TWithNonRegisteredRe
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -412,7 +412,7 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesBatchWithInvalidTokenA
 	s.NoError(err)
 	s.Len(remoteBatches, 1)
 
-	err = s.cmd.syncRemoteBatch(remoteBatches[0])
+	err = s.cmd.syncRemoteBatch(context.Background(), remoteBatches[0])
 	s.ErrorIs(err, ErrRollbackInProgress)
 
 	checkBatchAfterDispute(s.Assertions, s.cmd, remoteBatches[0].GetID())
@@ -484,7 +484,7 @@ func (s *TxsBatchesTestSuite) syncAllBlocks() {
 	latestBlockNumber, err := s.client.GetLatestBlockNumber()
 	s.NoError(err)
 
-	err = s.cmd.unsafeSyncBatches(0, *latestBlockNumber)
+	err = s.cmd.unsafeSyncBatches(context.Background(), 0, *latestBlockNumber)
 	s.NoError(err)
 }
 

--- a/commander/txs_tracking_test.go
+++ b/commander/txs_tracking_test.go
@@ -1,6 +1,7 @@
 package commander
 
 import (
+	"context"
 	"testing"
 
 	"github.com/Worldcoin/hubble-commander/bls"
@@ -110,7 +111,7 @@ func (s *TxsTrackingTestSuite) TestTrackSentTxs_MassMigrationTransaction() {
 func (s *TxsTrackingTestSuite) TestTrackSentTxs_BatchAccountRegistrationTransaction() {
 	s.setupTestWithClientConfig(&eth.ClientConfig{BatchAccountRegistrationGasLimit: ref.Uint64(lowGasLimit)})
 	publicKeys := make([]models.PublicKey, st.AccountBatchSize)
-	_, err := s.client.Client.RegisterBatchAccount(publicKeys)
+	_, err := s.client.Client.RegisterBatchAccount(context.Background(), publicKeys)
 	s.NoError(err)
 }
 
@@ -134,7 +135,7 @@ func (s *TxsTrackingTestSuite) TestTrackSentTxs_SubmitDepositBatch() {
 	executionCtx := executor.NewTestExecutionContext(s.storage.Storage, s.client.Client, nil)
 	depositsCtx := executor.NewTestDepositsContext(executionCtx)
 
-	_, _, err = depositsCtx.CreateAndSubmitBatch()
+	_, _, err = depositsCtx.CreateAndSubmitBatch(context.Background())
 	s.NoError(err)
 }
 
@@ -163,7 +164,7 @@ func (s *TxsTrackingTestSuite) submitBatch(tx models.GenericTransaction, batchTy
 	_, err = txsCtx.Mempool.AddOrReplace(s.storage.Storage, tx)
 	s.NoError(err)
 
-	batch, _, err := txsCtx.CreateAndSubmitBatch()
+	batch, _, err := txsCtx.CreateAndSubmitBatch(context.Background())
 	s.NoError(err)
 	s.client.Backend.Commit()
 	return batch

--- a/commander/workers.go
+++ b/commander/workers.go
@@ -29,6 +29,8 @@ func (w *workers) startWorker(name string, fn func() error) {
 		var err error
 		defer func() {
 			if recoverErr := recover(); recoverErr != nil {
+				log.Errorf("stacktrace from worker panic: %s", debug.Stack())
+
 				var ok bool
 				err, ok = recoverErr.(error)
 				if !ok {
@@ -37,7 +39,6 @@ func (w *workers) startWorker(name string, fn func() error) {
 			}
 			if err != nil {
 				log.Errorf("%s worker failed with: %+v", name, err)
-				log.Errorf("stacktrace from failure: %s", debug.Stack())
 				w.stopWorkersContext()
 			}
 			w.workersWaitGroup.Done()

--- a/db/tx_controller.go
+++ b/db/tx_controller.go
@@ -2,6 +2,8 @@ package db
 
 import (
 	"fmt"
+
+	"github.com/pkg/errors"
 )
 
 type rawController interface {
@@ -31,7 +33,11 @@ func (t *TxController) Rollback(cause *error) {
 func (t *TxController) Commit() error {
 	if !t.isLocked {
 		t.isLocked = true
-		return t.tx.Commit()
+		err := t.tx.Commit()
+		if err != nil {
+			return errors.WithStack(err)
+		}
+		return nil
 	}
 	return nil
 }

--- a/e2e/bench/bench_transactions_test.go
+++ b/e2e/bench/bench_transactions_test.go
@@ -51,10 +51,12 @@ func (s *BenchmarkTransactionsSuite) TestBenchCreate2TransfersCommander() {
 }
 
 func (s *BenchmarkTransactionsSuite) TestBenchMassMigrationsCommander() {
+	time.Sleep(time.Second * 15)  // give the NewBlockLoop a change to notice the spoke
 	s.sendTransactionsWithDistribution(TxTypeDistribution{txtype.MassMigration: 1.0})
 }
 
 func (s *BenchmarkTransactionsSuite) TestBenchMixedCommander() {
+	time.Sleep(time.Second * 15)  // give the NewBlockLoop a change to notice the spoke
 	s.sendTransactionsWithDistribution(TxTypeDistribution{
 		txtype.Transfer:        0.75,
 		txtype.Create2Transfer: 0.2,

--- a/e2e/bench/bench_transactions_test.go
+++ b/e2e/bench/bench_transactions_test.go
@@ -65,6 +65,7 @@ func (s *BenchmarkTransactionsSuite) TestBenchMixedCommander() {
 }
 
 func (s *BenchmarkTransactionsSuite) TestBenchSyncCommander() {
+	time.Sleep(time.Second * 15) // give the NewBlockLoop a change to notice the spoke
 	s.sendTransactionsWithDistribution(TxTypeDistribution{
 		txtype.Transfer:        0.75,
 		txtype.Create2Transfer: 0.2,

--- a/e2e/bench/bench_transactions_test.go
+++ b/e2e/bench/bench_transactions_test.go
@@ -51,12 +51,12 @@ func (s *BenchmarkTransactionsSuite) TestBenchCreate2TransfersCommander() {
 }
 
 func (s *BenchmarkTransactionsSuite) TestBenchMassMigrationsCommander() {
-	time.Sleep(time.Second * 15)  // give the NewBlockLoop a change to notice the spoke
+	time.Sleep(time.Second * 15) // give the NewBlockLoop a change to notice the spoke
 	s.sendTransactionsWithDistribution(TxTypeDistribution{txtype.MassMigration: 1.0})
 }
 
 func (s *BenchmarkTransactionsSuite) TestBenchMixedCommander() {
-	time.Sleep(time.Second * 15)  // give the NewBlockLoop a change to notice the spoke
+	time.Sleep(time.Second * 15) // give the NewBlockLoop a change to notice the spoke
 	s.sendTransactionsWithDistribution(TxTypeDistribution{
 		txtype.Transfer:        0.75,
 		txtype.Create2Transfer: 0.2,

--- a/e2e/commander_test.go
+++ b/e2e/commander_test.go
@@ -208,7 +208,7 @@ func (s *CoreCommanderE2ETestSuite) testMaxBatchDelay(startNonce uint64) {
 	s.Eventually(func() bool {
 		txReceipt = s.GetTransaction(txHash)
 		return txReceipt.Status == txstatus.Mined
-	}, 10*time.Second, testutils.TryInterval)
+	}, 20*time.Second, testutils.TryInterval)
 }
 
 func (s *CoreCommanderE2ETestSuite) testUserStateAfterTransfers(

--- a/e2e/dispute_utils_test.go
+++ b/e2e/dispute_utils_test.go
@@ -281,7 +281,7 @@ func (s *DisputesE2ETestSuite) sendC2TCommitment(encodedTransfer []byte, batchID
 }
 
 func (s *DisputesE2ETestSuite) submitC2TBatch(commitments []models.CommitmentWithTxs, batchID uint64) {
-	transaction, err := s.ETHClient.SubmitCreate2TransfersBatch(models.NewUint256(batchID), commitments)
+	transaction, err := s.ETHClient.SubmitCreate2TransfersBatch(context.Background(), models.NewUint256(batchID), commitments)
 	s.NoError(err)
 
 	s.waitForSubmittedBatch(transaction, batchID)

--- a/e2e/setup/e2e_test_suite_utils.go
+++ b/e2e/setup/e2e_test_suite_utils.go
@@ -53,7 +53,7 @@ func (s *E2ETestSuite) newEthClient(privateKey string) *eth.Client {
 		GenesisAccounts:                chainSpec.GenesisAccounts,
 	}
 
-	cfg := config.GetConfig()
+	cfg := config.GetCommanderConfigAndSetupLogger()
 	cfg.Ethereum.PrivateKey = privateKey
 	blockchain, err := chain.NewRPCConnection(cfg.Ethereum)
 	s.NoError(err)

--- a/e2e/setup/in_process_commander.go
+++ b/e2e/setup/in_process_commander.go
@@ -22,7 +22,7 @@ type InProcessCommander struct {
 
 func DeployAndCreateInProcessCommander(commanderConfig *config.Config, deployerConfig *config.DeployerConfig) (*InProcessCommander, error) {
 	if commanderConfig == nil {
-		commanderConfig = config.GetConfig()
+		commanderConfig = config.GetCommanderConfigAndSetupLogger()
 	}
 
 	commanderConfig.Badger.Path += "_e2e"

--- a/eth/account_manager.go
+++ b/eth/account_manager.go
@@ -1,6 +1,7 @@
 package eth
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -11,6 +12,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type AccountManager struct {
@@ -42,13 +44,25 @@ func NewAccountManager(blockchain chain.Connection, params *AccountManagerParams
 }
 
 func (a *AccountManager) packAndRequest(
+	ctx context.Context,
 	contract *Contract,
+	attributes []attribute.KeyValue,
 	opts *bind.TransactOpts,
 	shouldTrackTx bool,
 	method string,
 	data ...interface{},
 ) (*types.Transaction, error) {
-	return packAndRequest(a.txsChannels, contract, opts, shouldTrackTx, method, data...)
+	return packAndRequest(
+		ctx,
+		a.txsChannels,
+		contract,
+		"AccountManager",
+		attributes,
+		opts,
+		shouldTrackTx,
+		method,
+		data...,
+	)
 }
 
 type AccountManagerParams struct {

--- a/eth/chain/rpc_connection.go
+++ b/eth/chain/rpc_connection.go
@@ -74,7 +74,7 @@ func (c *RPCConnection) GetLatestBlockNumber() (*uint64, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ref.Uint64(blockNumber), nil
+	return ref.Uint64(blockNumber-10), nil
 }
 
 func (c *RPCConnection) SubscribeNewHead(ch chan<- *types.Header) (ethereum.Subscription, error) {

--- a/eth/chain/rpc_connection.go
+++ b/eth/chain/rpc_connection.go
@@ -74,7 +74,7 @@ func (c *RPCConnection) GetLatestBlockNumber() (*uint64, error) {
 	if err != nil {
 		return nil, err
 	}
-	return ref.Uint64(blockNumber-10), nil
+	return ref.Uint64(blockNumber - 10), nil
 }
 
 func (c *RPCConnection) SubscribeNewHead(ch chan<- *types.Header) (ethereum.Subscription, error) {

--- a/eth/client.go
+++ b/eth/client.go
@@ -131,7 +131,7 @@ func fillWithDefaults(c *ClientConfig) {
 		c.TxMineTimeout = ref.Duration(config.DefaultEthereumMineTimeout)
 	}
 	if c.StakeAmount == nil {
-		c.StakeAmount = models.NewUint256(1e17) // default 0.1 ether
+		c.StakeAmount = models.NewUint256(1e15) // default 0.001 ether
 	}
 	if c.TransferBatchSubmissionGasLimit == nil {
 		c.TransferBatchSubmissionGasLimit = ref.Uint64(config.DefaultTransferBatchSubmissionGasLimit)

--- a/eth/deployer/rollup/rollup.go
+++ b/eth/deployer/rollup/rollup.go
@@ -33,7 +33,7 @@ import (
 const (
 	DefaultMaxDepositSubtreeDepth = 2
 	DefaultGenesisStateRoot       = "cf277fb80a82478460e8988570b718f1e083ceb76f7e271a1a1497e5975f53ae"
-	DefaultStakeAmount            = 1e17
+	DefaultStakeAmount            = 1e15
 	DefaultMinGasLeft             = 10_000
 	DefaultMaxTxsPerCommit        = 32
 

--- a/eth/dispute_transition.go
+++ b/eth/dispute_transition.go
@@ -122,9 +122,12 @@ func (c *Client) waitForDispute(batchID *models.Uint256, batchHash *common.Hash,
 	}
 	err = c.GetRevertMessage(tx, receipt)
 	if err != nil {
-		return NewDisputeTxRevertedError(batchID.Uint64(), err.Error())
+		// one day in the far future it would be nice to stitch the solidity
+		// stack/call trace onto the other end of this one
+		result := NewDisputeTxRevertedError(batchID.Uint64(), err.Error())
+		return errors.WithStack(result)
 	}
-	return NewUnknownDisputeTxRevertedError(batchID.Uint64())
+	return errors.WithStack(NewUnknownDisputeTxRevertedError(batchID.Uint64()))
 }
 
 func (c *Client) isBatchAlreadyDisputed(batchID *models.Uint256, batchHash *common.Hash) error {

--- a/eth/get_batches_test.go
+++ b/eth/get_batches_test.go
@@ -88,7 +88,7 @@ func (s *GetBatchesTestSuite) TestGetBatches_FiltersByBlockNumber() {
 	batch2, err := s.client.SubmitTransfersBatchAndWait(models.NewUint256(2), []models.CommitmentWithTxs{&s.commitments[1]})
 	s.NoError(err)
 
-	batches, err := s.client.GetBatches(&BatchesFilters{
+	batches, err := s.client.GetBatches(context.Background(), &BatchesFilters{
 		StartBlockInclusive: uint64(*batch1.FinalisationBlock - uint32(*finalisationBlocks) + 1),
 	})
 	s.NoError(err)
@@ -104,7 +104,7 @@ func (s *GetBatchesTestSuite) TestGetBatches_FiltersByBatchID() {
 	batch2, err := s.client.SubmitTransfersBatchAndWait(models.NewUint256(2), []models.CommitmentWithTxs{&s.commitments[1]})
 	s.NoError(err)
 
-	batches, err := s.client.GetBatches(&BatchesFilters{
+	batches, err := s.client.GetBatches(context.Background(), &BatchesFilters{
 		FilterByBatchID: func(batchID *models.Uint256) bool {
 			return batchID.CmpN(0) > 0 && batchID.Cmp(&batch2.ID) < 0
 		},

--- a/eth/get_mm_batches_test.go
+++ b/eth/get_mm_batches_test.go
@@ -57,7 +57,7 @@ func (s *GetMMBatchesTestSuite) TestGetBatches() {
 	batch, err := s.client.SubmitMassMigrationsBatchAndWait(models.NewUint256(1), []models.CommitmentWithTxs{s.commitment})
 	s.NoError(err)
 
-	batches, err := s.client.GetBatches(&BatchesFilters{
+	batches, err := s.client.GetBatches(context.Background(), &BatchesFilters{
 		FilterByBatchID: func(batchID *models.Uint256) bool {
 			return batchID.CmpN(0) > 0
 		},

--- a/eth/sending_request.go
+++ b/eth/sending_request.go
@@ -85,7 +85,7 @@ func packAndRequest(
 	qualifiedName := contractName + "." + method
 	attributes = append(
 		attributes,
-		attribute.String("method", qualifiedName),
+		attribute.String("hubble.method", qualifiedName),
 	)
 	span.SetAttributes(attributes...)
 
@@ -107,7 +107,7 @@ func (c *TxSendingRequest) Send(nonce uint64) (*types.Transaction, error) {
 	_, span := clientTracer.Start(c.ctx, "TxSendingRequest.Send")
 	defer span.End()
 
-	span.SetAttributes(attribute.Int64("nonce", int64(nonce)))
+	span.SetAttributes(attribute.Int64("hubble.nonce", int64(nonce)))
 
 	c.opts.Nonce = big.NewInt(int64(nonce))
 	tx, err := c.contract.RawTransact(&c.opts, c.input)
@@ -117,7 +117,7 @@ func (c *TxSendingRequest) Send(nonce uint64) (*types.Transaction, error) {
 	}
 
 	if tx != nil {
-		span.SetAttributes(attribute.String("txHash", tx.Hash().String()))
+		span.SetAttributes(attribute.String("hubble.txHash", tx.Hash().String()))
 	}
 
 	if err != nil {

--- a/eth/sending_request.go
+++ b/eth/sending_request.go
@@ -1,10 +1,14 @@
 package eth
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/ethereum/go-ethereum/accounts/abi/bind"
 	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 )
 
 type TxSendingRequest struct {
@@ -13,6 +17,9 @@ type TxSendingRequest struct {
 	opts          bind.TransactOpts
 	ShouldTrackTx bool
 	ResultTxChan  chan SendResponse
+
+	// for creating spans
+	ctx    context.Context
 }
 
 type SendResponse struct {
@@ -29,18 +36,34 @@ type TxsTrackingChannels struct {
 }
 
 func (c *Client) packAndRequest(
+	ctx context.Context,
 	contract *Contract,
+	contractName string,
+	attributes []attribute.KeyValue,
 	opts *bind.TransactOpts,
 	shouldTrackTx bool,
 	method string,
 	data ...interface{},
 ) (*types.Transaction, error) {
-	return packAndRequest(c.txsChannels, contract, opts, shouldTrackTx, method, data...)
+	return packAndRequest(
+		ctx,
+		c.txsChannels,
+		contract,
+		contractName,
+		attributes,
+		opts,
+		shouldTrackTx,
+		method,
+		data...,
+	)
 }
 
 func packAndRequest(
+	ctx context.Context,
 	txsChannels *TxsTrackingChannels,
 	contract *Contract,
+	contractName string,
+	attributes []attribute.KeyValue,
 	opts *bind.TransactOpts,
 	shouldTrackTx bool,
 	method string,
@@ -52,8 +75,19 @@ func packAndRequest(
 	}
 
 	if txsChannels.SkipChannelSending {
+		// todo: instrument this path?
 		return contract.BoundContract.RawTransact(opts, input)
 	}
+
+	spanCtx, span := clientTracer.Start(ctx, "packAndRequest")
+	defer span.End()
+
+	qualifiedName := contractName + "." + method
+	attributes = append(
+		attributes,
+		attribute.String("method", qualifiedName),
+	)
+	span.SetAttributes(attributes...)
 
 	responseChan := make(chan SendResponse, 1)
 	txsChannels.Requests <- &TxSendingRequest{
@@ -62,17 +96,36 @@ func packAndRequest(
 		opts:          *opts,
 		ShouldTrackTx: shouldTrackTx,
 		ResultTxChan:  responseChan,
+
+		ctx: spanCtx,
 	}
 	response := <-responseChan
 	return response.Transaction, response.Error
 }
 
 func (c *TxSendingRequest) Send(nonce uint64) (*types.Transaction, error) {
+	_, span := clientTracer.Start(c.ctx, "TxSendingRequest.Send")
+	defer span.End()
+
+	span.SetAttributes(attribute.Int64("nonce", int64(nonce)))
+
 	c.opts.Nonce = big.NewInt(int64(nonce))
 	tx, err := c.contract.RawTransact(&c.opts, c.input)
 	c.ResultTxChan <- SendResponse{
 		Transaction: tx,
 		Error:       err,
 	}
-	return tx, err
+
+	if tx != nil {
+		span.SetAttributes(attribute.String("txHash", tx.Hash().String()))
+	}
+
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, "")
+		return nil, errors.WithStack(err)
+	}
+
+	span.SetStatus(codes.Ok, "")
+	return tx, nil
 }

--- a/eth/sending_request.go
+++ b/eth/sending_request.go
@@ -19,7 +19,7 @@ type TxSendingRequest struct {
 	ResultTxChan  chan SendResponse
 
 	// for creating spans
-	ctx    context.Context
+	ctx context.Context
 }
 
 type SendResponse struct {

--- a/eth/session_builder.go
+++ b/eth/session_builder.go
@@ -2,6 +2,7 @@
 package eth
 
 import (
+	"context"
 	"math/big"
 
 	"github.com/Worldcoin/hubble-commander/contracts/accountregistry"
@@ -11,6 +12,7 @@ import (
 	"github.com/Worldcoin/hubble-commander/contracts/tokenregistry"
 	"github.com/Worldcoin/hubble-commander/models"
 	"github.com/ethereum/go-ethereum/core/types"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type packAndRequestFunc func(shouldTrackTx bool, method string, data ...interface{}) (*types.Transaction, error)
@@ -19,6 +21,9 @@ type rollupSessionBuilder struct {
 	rollup.RollupSession
 	contract       Contract
 	packAndRequest packAndRequestFunc
+
+	attributes []attribute.KeyValue
+	ctx        context.Context
 }
 
 func (c *Client) rollup() *rollupSessionBuilder {
@@ -28,13 +33,25 @@ func (c *Client) rollup() *rollupSessionBuilder {
 			TransactOpts: *c.Blockchain.GetAccount(),
 		},
 		contract: c.Rollup.Contract,
+		attributes: make([]attribute.KeyValue, 0),
+		ctx: context.Background(),
 	}
 
 	builder.packAndRequest = func(shouldTrackTx bool, method string, data ...interface{}) (*types.Transaction, error) {
-		return c.packAndRequest(&builder.contract, &builder.TransactOpts, shouldTrackTx, method, data...)
+		return c.packAndRequest(builder.ctx, &builder.contract, "Rollup", builder.attributes, &builder.TransactOpts, shouldTrackTx, method, data...)
 	}
 
 	return &builder
+}
+
+func (b *rollupSessionBuilder) WithAttribute(kv attribute.KeyValue) *rollupSessionBuilder {
+	b.attributes = append(b.attributes, kv)
+	return b
+}
+
+func (b *rollupSessionBuilder) WithContext(ctx context.Context) *rollupSessionBuilder {
+	b.ctx = ctx
+	return b
 }
 
 func (b *rollupSessionBuilder) WithValue(value *models.Uint256) *rollupSessionBuilder {
@@ -149,6 +166,9 @@ type accountRegistrySessionBuilder struct {
 	accountregistry.AccountRegistrySession
 	contract       Contract
 	packAndRequest packAndRequestFunc
+
+	attributes []attribute.KeyValue
+	ctx        context.Context
 }
 
 func (a *AccountManager) accountRegistry() *accountRegistrySessionBuilder {
@@ -158,13 +178,33 @@ func (a *AccountManager) accountRegistry() *accountRegistrySessionBuilder {
 			TransactOpts: *a.Blockchain.GetAccount(),
 		},
 		contract: a.AccountRegistry.Contract,
+		attributes: make([]attribute.KeyValue, 0),
+		ctx: context.Background(),
 	}
 
 	builder.packAndRequest = func(shouldTrackTx bool, method string, data ...interface{}) (*types.Transaction, error) {
-		return a.packAndRequest(&builder.contract, &builder.TransactOpts, shouldTrackTx, method, data...)
+		return a.packAndRequest(
+			builder.ctx,
+			&builder.contract,
+			builder.attributes,
+			&builder.TransactOpts,
+			shouldTrackTx,
+			method,
+			data...,
+		)
 	}
 
 	return &builder
+}
+
+func (b *accountRegistrySessionBuilder) WithContext(ctx context.Context) *accountRegistrySessionBuilder {
+	b.ctx = ctx
+	return b
+}
+
+func (b *accountRegistrySessionBuilder) WithAttribute(kv attribute.KeyValue) *accountRegistrySessionBuilder {
+	b.attributes = append(b.attributes, kv)
+	return b
 }
 
 func (b *accountRegistrySessionBuilder) WithValue(value *models.Uint256) *accountRegistrySessionBuilder {

--- a/eth/session_builder.go
+++ b/eth/session_builder.go
@@ -32,13 +32,22 @@ func (c *Client) rollup() *rollupSessionBuilder {
 			Contract:     c.Rollup.Rollup,
 			TransactOpts: *c.Blockchain.GetAccount(),
 		},
-		contract: c.Rollup.Contract,
+		contract:   c.Rollup.Contract,
 		attributes: make([]attribute.KeyValue, 0),
-		ctx: context.Background(),
+		ctx:        context.Background(),
 	}
 
 	builder.packAndRequest = func(shouldTrackTx bool, method string, data ...interface{}) (*types.Transaction, error) {
-		return c.packAndRequest(builder.ctx, &builder.contract, "Rollup", builder.attributes, &builder.TransactOpts, shouldTrackTx, method, data...)
+		return c.packAndRequest(
+			builder.ctx,
+			&builder.contract,
+			"Rollup",
+			builder.attributes,
+			&builder.TransactOpts,
+			shouldTrackTx,
+			method,
+			data...,
+		)
 	}
 
 	return &builder
@@ -177,9 +186,9 @@ func (a *AccountManager) accountRegistry() *accountRegistrySessionBuilder {
 			Contract:     a.AccountRegistry.AccountRegistry,
 			TransactOpts: *a.Blockchain.GetAccount(),
 		},
-		contract: a.AccountRegistry.Contract,
+		contract:   a.AccountRegistry.Contract,
 		attributes: make([]attribute.KeyValue, 0),
-		ctx: context.Background(),
+		ctx:        context.Background(),
 	}
 
 	builder.packAndRequest = func(shouldTrackTx bool, method string, data ...interface{}) (*types.Transaction, error) {

--- a/eth/submit_batch.go
+++ b/eth/submit_batch.go
@@ -1,6 +1,8 @@
 package eth
 
 import (
+	"context"
+
 	"github.com/Worldcoin/hubble-commander/contracts/rollup"
 	"github.com/Worldcoin/hubble-commander/encoder"
 	"github.com/Worldcoin/hubble-commander/models"
@@ -8,6 +10,7 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
+	"go.opentelemetry.io/otel/attribute"
 )
 
 type SubmitBatchFunc func() (*types.Transaction, error)
@@ -23,10 +26,12 @@ func (c *Client) SubmitTransfersBatch(batchID *models.Uint256, commitments []mod
 	return tx, nil
 }
 
-func (c *Client) SubmitCreate2TransfersBatch(batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error) {
+func (c *Client) SubmitCreate2TransfersBatch(ctx context.Context, batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error) {
 	tx, err := c.rollup().
 		WithValue(c.config.StakeAmount).
 		WithGasLimit(*c.config.C2TBatchSubmissionGasLimit).
+		WithContext(ctx).
+		WithAttribute(attribute.String("batchID", batchID.String())).
 		SubmitCreate2Transfer(encoder.CommitmentsToTransferAndC2TSubmitBatchFields(batchID, commitments))
 	if err != nil {
 		return nil, errors.WithStack(err)
@@ -58,7 +63,7 @@ func (c *Client) SubmitCreate2TransfersBatchAndWait(
 	commitments []models.CommitmentWithTxs,
 ) (*models.Batch, error) {
 	return c.submitBatchAndWait(func() (*types.Transaction, error) {
-		return c.SubmitCreate2TransfersBatch(batchID, commitments)
+		return c.SubmitCreate2TransfersBatch(context.TODO(), batchID, commitments)
 	})
 }
 

--- a/eth/submit_batch.go
+++ b/eth/submit_batch.go
@@ -26,7 +26,11 @@ func (c *Client) SubmitTransfersBatch(batchID *models.Uint256, commitments []mod
 	return tx, nil
 }
 
-func (c *Client) SubmitCreate2TransfersBatch(ctx context.Context, batchID *models.Uint256, commitments []models.CommitmentWithTxs) (*types.Transaction, error) {
+func (c *Client) SubmitCreate2TransfersBatch(
+	ctx context.Context,
+	batchID *models.Uint256,
+	commitments []models.CommitmentWithTxs,
+) (*types.Transaction, error) {
 	tx, err := c.rollup().
 		WithValue(c.config.StakeAmount).
 		WithGasLimit(*c.config.C2TBatchSubmissionGasLimit).

--- a/eth/test_client.go
+++ b/eth/test_client.go
@@ -2,7 +2,6 @@ package eth
 
 import (
 	"github.com/Worldcoin/hubble-commander/bls"
-	"github.com/Worldcoin/hubble-commander/eth/chain"
 	"github.com/Worldcoin/hubble-commander/eth/deployer/rollup"
 	"github.com/Worldcoin/hubble-commander/metrics"
 	"github.com/Worldcoin/hubble-commander/models"
@@ -39,12 +38,7 @@ func NewConfiguredTestClient(cfg *rollup.DeploymentConfig, clientCfg *TestClient
 		return nil, err
 	}
 
-	wrappedConn, err := chain.NewManualNonceConnection(sim)
-	if err != nil {
-		return nil, err
-	}
-
-	contracts, err := rollup.DeployConfiguredRollup(wrappedConn, cfg)
+	contracts, err := rollup.DeployConfiguredRollup(sim, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/storage/database.go
+++ b/storage/database.go
@@ -45,6 +45,7 @@ func (d *Database) BeginTransaction(opts TxOptions) (*db.TxController, *Database
 func (d *Database) ExecuteInTransaction(opts TxOptions, fn func(txDatabase *Database) error) error {
 	err := d.unsafeExecuteInTransaction(opts, fn)
 	if errors.Is(err, bdg.ErrConflict) {
+		log.Debug("ExecuteInTransaction transaction conflicted, trying again")
 		return d.ExecuteInTransaction(opts, fn)
 	}
 	return err

--- a/storage/state_tree.go
+++ b/storage/state_tree.go
@@ -45,7 +45,7 @@ func (s *StateTree) Leaf(stateID uint32) (stateLeaf *models.StateLeaf, err error
 		return nil, errors.WithStack(NewNotFoundError("state leaf"))
 	}
 	if err != nil {
-		return nil, err
+		return nil, errors.WithStack(err)
 	}
 	return storedLeaf.ToModelsStateLeaf(), nil
 }


### PR DESCRIPTION
- The New Block Loop was accidentally reporting itself as the Rollup
  Loop, it now uses a tracer with a better name
- Added spans to every outgoing transaction: we now know how long it
  took to talk to the ethereum node for every transaction we attempt to
  send.
- Threaded spans and contexts through much of the Rollup Loop call tree,
  allowing us to associate each iteration of the Rollup Loop with the
  transactions which it submits to the chain.
- Do a better job of recording stack traces when workers fail. We were
  asking for the stack while not inside of the recover() block which
  makes an uncertain difference but is better form and _seems_ to have
  been an improvement.
- calls errors.WithStack() in more places where we were not wrapping
  native error values and therefore not getting stack traces.
- add a 10 block delay to the New Block Loop so that we do not trigger the
  race condition where the Rollup and New Block loops walk over each
  other. This is a temporary measure while we wait for the proper fix.
- reduce the default stake amount by two orders of magnitude to account
  for the fact that we are the only proposer and we trust ourselves and
  0.1 eth per batch is a lot of money to be locking up.