### PR TITLE
Add `admin_` methods for fixing broken pending states

### DIFF
--- a/api/admin/api.go
+++ b/api/admin/api.go
@@ -29,3 +29,13 @@ func NewAPI(
 		enableTxsAcceptance: enableTxsAcceptance,
 	}
 }
+
+func NewTestAPI(
+	cfg *config.APIConfig,
+	storage *st.Storage,
+	client *eth.Client,
+) *API {
+	return NewAPI(
+		cfg, storage, client, nil, nil,
+	)
+}

--- a/api/admin/mempool.go
+++ b/api/admin/mempool.go
@@ -14,3 +14,12 @@ func (a *API) RecomputePendingState(ctx context.Context, stateID uint32, mutate 
 
 	return a.storage.RecomputePendingState(stateID, mutate)
 }
+
+func (a *API) GetPendingStates(ctx context.Context, startStateID uint32, pageSize uint32) ([]dto.UserStateWithID, error) {
+	err := a.verifyAuthKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.storage.GetPendingStates(startStateID, pageSize)
+}

--- a/api/admin/mempool.go
+++ b/api/admin/mempool.go
@@ -15,7 +15,7 @@ func (a *API) RecomputePendingState(ctx context.Context, stateID uint32, mutate 
 	return a.storage.RecomputePendingState(stateID, mutate)
 }
 
-func (a *API) GetPendingStates(ctx context.Context, startStateID uint32, pageSize uint32) ([]dto.UserStateWithID, error) {
+func (a *API) GetPendingStates(ctx context.Context, startStateID, pageSize uint32) ([]dto.UserStateWithID, error) {
 	err := a.verifyAuthKey(ctx)
 	if err != nil {
 		return nil, err

--- a/api/admin/mempool.go
+++ b/api/admin/mempool.go
@@ -1,0 +1,16 @@
+package admin
+
+import (
+	"context"
+
+	"github.com/Worldcoin/hubble-commander/models/dto"
+)
+
+func (a *API) RecomputePendingState(ctx context.Context, stateID uint32, mutate bool) (*dto.RecomputePendingState, error) {
+	err := a.verifyAuthKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.storage.RecomputePendingState(stateID, mutate)
+}

--- a/api/mempool_test.go
+++ b/api/mempool_test.go
@@ -51,7 +51,7 @@ func (s *MempoolTestSuite) SetupTest() {
 	)
 }
 
-func contextWithAuthKey(authKeyValue string) context.Context {
+func contextWithAuthKey() context.Context {
 	return context.WithValue(context.Background(), rpc.AuthKey, authKeyValue)
 }
 
@@ -62,13 +62,13 @@ func (s *MempoolTestSuite) TearDownTest() {
 }
 
 func (s *MempoolTestSuite) TestGetPendingStates_EmptyMempool() {
-	result, err := s.adminAPI.GetPendingStates(contextWithAuthKey(authKeyValue), 0, 1000)
+	result, err := s.adminAPI.GetPendingStates(contextWithAuthKey(), 0, 1000)
 	s.NoError(err)
 	s.Len(result, 0)
 }
 
 // TODO: this is a good spot for a proptest!
-//nolint:funlen
+
 func (s *MempoolTestSuite) TestRecomputeState() {
 	// I. Setup: create some accounts
 
@@ -102,7 +102,7 @@ func (s *MempoolTestSuite) TestRecomputeState() {
 	// IV. With mutate=false the pending state should not be changed
 
 	doNotMutate := false
-	result, err := s.adminAPI.RecomputePendingState(contextWithAuthKey(authKeyValue), firstStateID, doNotMutate)
+	result, err := s.adminAPI.RecomputePendingState(contextWithAuthKey(), firstStateID, doNotMutate)
 	s.NoError(err)
 	s.Equal(&dto.RecomputePendingState{
 		OldNonce:   models.MakeUint256(0),
@@ -115,7 +115,7 @@ func (s *MempoolTestSuite) TestRecomputeState() {
 	// V. With mutate=true the pending state should be fixed!
 
 	pleaseMutate := true
-	result, err = s.adminAPI.RecomputePendingState(contextWithAuthKey(authKeyValue), firstStateID, pleaseMutate)
+	result, err = s.adminAPI.RecomputePendingState(contextWithAuthKey(), firstStateID, pleaseMutate)
 	s.NoError(err)
 	s.Equal(&dto.RecomputePendingState{
 		OldNonce:   models.MakeUint256(0),
@@ -125,7 +125,7 @@ func (s *MempoolTestSuite) TestRecomputeState() {
 	}, result)
 	s.assertAPIBalance(firstStateID, 70)
 
-	result, err = s.adminAPI.RecomputePendingState(contextWithAuthKey(authKeyValue), firstStateID, doNotMutate)
+	result, err = s.adminAPI.RecomputePendingState(contextWithAuthKey(), firstStateID, doNotMutate)
 	s.NoError(err)
 	s.Equal(&dto.RecomputePendingState{
 		OldNonce:   models.MakeUint256(2),
@@ -136,7 +136,7 @@ func (s *MempoolTestSuite) TestRecomputeState() {
 }
 
 func (s *MempoolTestSuite) assertPendingStates(startID, pageSize uint32, expected []dto.UserStateWithID) {
-	pendingStates, err := s.adminAPI.GetPendingStates(contextWithAuthKey(authKeyValue), startID, pageSize)
+	pendingStates, err := s.adminAPI.GetPendingStates(contextWithAuthKey(), startID, pageSize)
 	s.NoError(err)
 	s.Equal(expected, pendingStates)
 }

--- a/api/mempool_test.go
+++ b/api/mempool_test.go
@@ -1,0 +1,200 @@
+// we are testing a method from `api/admin` but we call methods in `api`. To break the import loop
+// this file lives in api.
+package api
+
+import (
+	"context"
+	"testing"
+
+	"github.com/Worldcoin/hubble-commander/api/admin"
+	"github.com/Worldcoin/hubble-commander/api/rpc"
+	"github.com/Worldcoin/hubble-commander/bls"
+	"github.com/Worldcoin/hubble-commander/config"
+	"github.com/Worldcoin/hubble-commander/eth"
+	"github.com/Worldcoin/hubble-commander/models"
+	"github.com/Worldcoin/hubble-commander/models/dto"
+	"github.com/Worldcoin/hubble-commander/storage"
+	"github.com/Worldcoin/hubble-commander/utils/ref"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+const authKeyValue = "secret key"
+
+type MempoolTestSuite struct {
+	*require.Assertions
+	suite.Suite
+	hubbleAPI *API
+	adminAPI  *admin.API
+	client    *eth.TestClient
+	storage   *storage.TestStorage
+}
+
+func (s *MempoolTestSuite) SetupSuite() {
+	s.Assertions = require.New(s.T())
+}
+
+func (s *MempoolTestSuite) SetupTest() {
+	var err error
+	s.storage, err = storage.NewTestStorage()
+	s.NoError(err)
+	s.client, err = eth.NewTestClient()
+	s.NoError(err)
+	s.adminAPI = admin.NewTestAPI(
+		&config.APIConfig{AuthenticationKey: authKeyValue},
+		s.storage.Storage,
+		s.client.Client,
+	)
+	s.hubbleAPI = NewTestAPI(
+		s.storage.Storage,
+		s.client.Client,
+	)
+}
+
+func contextWithAuthKey(authKeyValue string) context.Context {
+	return context.WithValue(context.Background(), rpc.AuthKey, authKeyValue)
+}
+
+func (s *MempoolTestSuite) TearDownTest() {
+	s.client.Close()
+	err := s.storage.Teardown()
+	s.NoError(err)
+}
+
+// TODO: this is a good spot for a proptest!
+//nolint:funlen
+func (s *MempoolTestSuite) TestRecomputeState() {
+	// I. Setup: create some accounts
+
+	domain, err := s.client.GetDomain()
+	s.NoError(err)
+
+	firstWallet, err := bls.NewRandomWallet(*domain)
+	s.NoError(err)
+
+	firstPubkeyID := uint32(1)
+	firstAccount := models.AccountLeaf{
+		PubKeyID:  firstPubkeyID,
+		PublicKey: *firstWallet.PublicKey(),
+	}
+	err = s.storage.AccountTree.SetSingle(&firstAccount)
+	s.NoError(err)
+
+	firstStateID := uint32(1)
+	_, err = s.storage.StateTree.Set(
+		firstStateID,
+		&models.UserState{
+			PubKeyID: firstAccount.PubKeyID,
+			TokenID:  models.MakeUint256(0),
+			Balance:  models.MakeUint256(100),
+			Nonce:    models.MakeUint256(0),
+		},
+	)
+	s.NoError(err)
+
+	secondWallet, err := bls.NewRandomWallet(*domain)
+	s.NoError(err)
+
+	secondPubkeyID := uint32(2)
+	secondAccount := models.AccountLeaf{
+		PubKeyID:  secondPubkeyID,
+		PublicKey: *secondWallet.PublicKey(),
+	}
+	err = s.storage.AccountTree.SetSingle(&secondAccount)
+	s.NoError(err)
+
+	secondStateID := uint32(2)
+	_, err = s.storage.StateTree.Set(
+		secondStateID,
+		&models.UserState{
+			PubKeyID: secondAccount.PubKeyID,
+			TokenID:  models.MakeUint256(0),
+			Balance:  models.MakeUint256(100),
+			Nonce:    models.MakeUint256(0),
+		},
+	)
+	s.NoError(err)
+
+	// II. Insert some mempool transactions
+
+	c2t := dto.Create2Transfer{
+		FromStateID: ref.Uint32(firstStateID),
+		ToPublicKey: secondWallet.PublicKey(),
+		Amount:      models.NewUint256(10),
+		Fee:         models.NewUint256(10),
+		Nonce:       models.NewUint256(0),
+		Signature:   &models.Signature{},
+	}
+
+	hash, err := s.hubbleAPI.SendTransaction(context.Background(), dto.MakeTransaction(c2t))
+	s.NoError(err)
+	s.NotNil(hash)
+
+	transfer := dto.Transfer{
+		FromStateID: ref.Uint32(firstStateID),
+		ToStateID:   ref.Uint32(secondStateID),
+		Amount:      models.NewUint256(10),
+		Fee:         models.NewUint256(10),
+		Nonce:       models.NewUint256(1),
+		Signature:   &models.Signature{},
+	}
+
+	hash, err = s.hubbleAPI.SendTransaction(context.Background(), dto.MakeTransaction(transfer))
+	s.NoError(err)
+	s.NotNil(hash)
+
+	transfer = dto.Transfer{
+		FromStateID: ref.Uint32(secondStateID),
+		ToStateID:   ref.Uint32(firstStateID),
+		Amount:      models.NewUint256(10),
+		Fee:         models.NewUint256(10),
+		Nonce:       models.NewUint256(0),
+		Signature:   &models.Signature{},
+	}
+
+	hash, err = s.hubbleAPI.SendTransaction(context.Background(), dto.MakeTransaction(transfer))
+	s.NoError(err)
+	s.NotNil(hash)
+
+	// III. Now that we have some mempool transactions, manually ruin the pending state
+
+	err = s.storage.UnsafeSetPendingState(firstStateID, models.MakeUint256(0), models.MakeUint256(0))
+	s.NoError(err)
+
+	// IV. With mutate=false the pending state should not be changed
+
+	doNotMutate := false
+	result, err := s.adminAPI.RecomputePendingState(contextWithAuthKey(authKeyValue), firstStateID, doNotMutate)
+	s.NoError(err)
+	s.Equal(&dto.RecomputePendingState{
+		OldNonce:   models.MakeUint256(0),
+		OldBalance: models.MakeUint256(0),
+		NewNonce:   models.MakeUint256(2),
+		NewBalance: models.MakeUint256(90),
+	}, result)
+
+	// V. With mutate=true the pending state should be fixed!
+
+	pleaseMutate := true
+	result, err = s.adminAPI.RecomputePendingState(contextWithAuthKey(authKeyValue), firstStateID, pleaseMutate)
+	s.NoError(err)
+	s.Equal(&dto.RecomputePendingState{
+		OldNonce:   models.MakeUint256(0),
+		OldBalance: models.MakeUint256(0),
+		NewNonce:   models.MakeUint256(2),
+		NewBalance: models.MakeUint256(90),
+	}, result)
+
+	result, err = s.adminAPI.RecomputePendingState(contextWithAuthKey(authKeyValue), firstStateID, doNotMutate)
+	s.NoError(err)
+	s.Equal(&dto.RecomputePendingState{
+		OldNonce:   models.MakeUint256(2),
+		OldBalance: models.MakeUint256(90),
+		NewNonce:   models.MakeUint256(2),
+		NewBalance: models.MakeUint256(90),
+	}, result)
+}
+
+func TestMempoolTestSuite(t *testing.T) {
+	suite.Run(t, new(MempoolTestSuite))
+}

--- a/models/dto/recompute_pending_state.go
+++ b/models/dto/recompute_pending_state.go
@@ -1,0 +1,10 @@
+package dto
+
+import "github.com/Worldcoin/hubble-commander/models"
+
+type RecomputePendingState struct {
+	OldNonce   models.Uint256
+	OldBalance models.Uint256
+	NewNonce   models.Uint256
+	NewBalance models.Uint256
+}


### PR DESCRIPTION
These two methods are sufficient for fixing the current incorrect state in Hubble as well as future problems with the state which might arise:

- `admin_getPendingStates(startStateID, pageSize)` returns the pending states, and supports pagination in case there are too many accounts to return in a single request.
- `admin_recomputePendingState(stateID, mutate)` processes the mempool, starting from the batched state, and returns both the current pending state and the correct pending state. If `mutate` is true then it updates the current pending state. It opens a transaction and will be serialized w.r.t any `hubble_sendTransaction` handlers.

There are tests and I've also tested it against a local hubble. The lint gh action is currently broken, ignore the failure, the linter is happy with this change.