### PR TITLE
Pending values use -1 instead of MAX_UINT32

### DIFF
--- a/api/get_user_state_test.go
+++ b/api/get_user_state_test.go
@@ -90,7 +90,7 @@ func (s *GetUserStateTestSuite) TestGetUserState() {
 	userState, err := s.api.GetUserState(context.Background(), 1)
 	s.NoError(err)
 
-	s.Equal(userState.StateID, uint32(1))
+	s.Equal(userState.StateID, int64(1))
 	s.Equal(userState.UserState.Nonce.Int.Uint64(), uint64(0))
 	s.Equal(userState.UserState.Balance.Int.Uint64(), uint64(100))
 
@@ -113,14 +113,14 @@ func (s *GetUserStateTestSuite) TestGetUserState() {
 	userState, err = s.api.GetUserState(context.Background(), uint32(senderStateID))
 	s.NoError(err)
 
-	s.Equal(uint32(senderStateID), userState.StateID)
+	s.Equal(int64(senderStateID), userState.StateID)
 	s.Equal(uint64(1), userState.UserState.Nonce.Int.Uint64())
 	s.Equal(uint64(40), userState.UserState.Balance.Int.Uint64())
 
 	userState, err = s.api.GetUserState(context.Background(), uint32(receiverStateID))
 	s.NoError(err)
 
-	s.Equal(uint32(receiverStateID), userState.StateID)
+	s.Equal(int64(receiverStateID), userState.StateID)
 	s.Equal(uint64(0), userState.UserState.Nonce.Int.Uint64())
 	s.Equal(uint64(50), userState.UserState.Balance.Int.Uint64())
 }

--- a/api/get_user_states.go
+++ b/api/get_user_states.go
@@ -56,10 +56,9 @@ func (a *API) unsafeGetUserStates(ctx context.Context, publicKey *models.PublicK
 			return err
 		}
 		for i := range pendingUserStates {
-			maxUint32 := ^uint32(0) // TODO: change the dto format
 			userStates = append(
 				userStates,
-				dto.MakeUserStateWithID(maxUint32, &pendingUserStates[i]),
+				dto.MakePendingUserStateWithID(&pendingUserStates[i]),
 			)
 		}
 

--- a/api/get_user_states_test.go
+++ b/api/get_user_states_test.go
@@ -124,7 +124,7 @@ func (s *GetUserStatesTestSuite) TestGetUserStates_ZipsBatchednAndPendingStates(
 		},
 	}, userStates[0])
 	s.Equal(dto.UserStateWithID{
-		StateID: ^uint32(0),
+		StateID: -1,
 		UserState: dto.UserState{
 			PubKeyID: 2,
 			TokenID:  models.MakeUint256(0),
@@ -174,9 +174,9 @@ func (s *GetUserStatesTestSuite) TestGetUserStates_HasPendingC2T() {
 	s.Len(userStates, 1)
 
 	s.Equal(userStates[0], dto.UserStateWithID{
-		StateID: ^uint32(0),
+		StateID: -1,
 		UserState: dto.UserState{
-			PubKeyID: ^uint32(0),
+			PubKeyID: -1,
 			TokenID:  models.MakeUint256(0),
 			Balance:  models.MakeUint256(50),
 			Nonce:    models.MakeUint256(0),

--- a/commander/consistent_api_test.go
+++ b/commander/consistent_api_test.go
@@ -115,9 +115,9 @@ func (s *APIConsistencySuite) TestGetUserStatesPendingToBatched() {
 	s.NoError(err)
 	s.Len(fetchedStates, 1)
 	s.Equal(dto.UserStateWithID{
-		StateID: ^uint32(0),
+		StateID: -1,
 		UserState: dto.UserState{
-			PubKeyID: ^uint32(0),
+			PubKeyID: -1,
 			TokenID:  models.MakeUint256(0),
 			Balance:  models.MakeUint256(20),
 			Nonce:    models.MakeUint256(0),
@@ -138,7 +138,7 @@ func (s *APIConsistencySuite) TestGetUserStatesPendingToBatched() {
 	s.Equal(dto.UserStateWithID{
 		StateID: 2,
 		UserState: dto.UserState{
-			PubKeyID: *nextPubkeyID,
+			PubKeyID: int64(*nextPubkeyID),
 			TokenID:  models.MakeUint256(0),
 			Balance:  models.MakeUint256(20),
 			Nonce:    models.MakeUint256(0),

--- a/e2e/bench/bench_test_suite.go
+++ b/e2e/bench/bench_test_suite.go
@@ -137,10 +137,16 @@ func (s *benchmarkTestSuite) sendTransactions(
 				continue
 			}
 
-			s.stateIds = append(s.stateIds, state.StateID)
+			if state.StateID < 0 {
+				continue
+			}
+
+			stateID := uint32(state.StateID)
+
+			s.stateIds = append(s.stateIds, stateID)
 
 			s.waitGroup.Add(1)
-			go s.runForWallet(wallet, state.StateID, walletAction)
+			go s.runForWallet(wallet, stateID, walletAction)
 
 			workers += 1
 			if workers >= int(s.benchConfig.MaxConcurrentWorkers) {

--- a/e2e/withdraw_test.go
+++ b/e2e/withdraw_test.go
@@ -59,7 +59,7 @@ func (s *WithdrawalsE2ETestSuite) SetupTest() {
 func (s *WithdrawalsE2ETestSuite) TestWithdrawals() {
 	newUserStates := s.makeDeposit()
 
-	targetMassMigrationHash := s.submitWithdrawBatch(newUserStates[0].StateID)
+	targetMassMigrationHash := s.submitWithdrawBatch(uint32(newUserStates[0].StateID))
 
 	s.testProcessWithdrawCommitment()
 
@@ -114,7 +114,7 @@ func (s *WithdrawalsE2ETestSuite) testClaimTokens(transactionHash common.Hash) {
 	message, err := s.senderWallet.Sign(s.transactor.From.Bytes())
 	s.NoError(err)
 
-	publicKeyProof := s.getPublicKeyProof(proof.UserState.PubKeyID)
+	publicKeyProof := s.getPublicKeyProof(uint32(proof.UserState.PubKeyID))
 
 	expectedBalanceDifference := *proof.UserState.Balance.MulN(consts.L2Unit)
 	s.testDoActionAndAssertTokenBalanceDifference(s.transactor.From, expectedBalanceDifference, func() {
@@ -215,11 +215,11 @@ func (s *WithdrawalsE2ETestSuite) sendMMFromWallet(wallet bls.Wallet, massMigrat
 func (s *WithdrawalsE2ETestSuite) userStatesDifference(a, b []dto.UserStateWithID) []dto.UserStateWithID {
 	mb := make(map[uint32]struct{}, len(b))
 	for _, x := range b {
-		mb[x.StateID] = struct{}{}
+		mb[uint32(x.StateID)] = struct{}{}
 	}
 	var diff []dto.UserStateWithID
 	for _, x := range a {
-		if _, found := mb[x.StateID]; !found {
+		if _, found := mb[uint32(x.StateID)]; !found {
 			diff = append(diff, x)
 		}
 	}
@@ -305,7 +305,7 @@ func (s *WithdrawalsE2ETestSuite) getPublicKeyProof(pubKeyID uint32) dto.PublicK
 func (s *WithdrawalsE2ETestSuite) withdrawProofToCalldata(proof *dto.WithdrawProof) withdrawmanager.TypesStateMerkleProofWithPath {
 	return withdrawmanager.TypesStateMerkleProofWithPath{
 		State: withdrawmanager.TypesUserState{
-			PubkeyID: big.NewInt(int64(proof.UserState.PubKeyID)),
+			PubkeyID: big.NewInt(proof.UserState.PubKeyID),
 			TokenID:  proof.UserState.TokenID.ToBig(),
 			Balance:  proof.UserState.Balance.ToBig(),
 			Nonce:    proof.UserState.Nonce.ToBig(),

--- a/models/dto/user_state.go
+++ b/models/dto/user_state.go
@@ -5,27 +5,52 @@ import (
 )
 
 type UserState struct {
-	PubKeyID uint32
+	PubKeyID int64
 	TokenID  models.Uint256
 	Balance  models.Uint256
 	Nonce    models.Uint256
 }
 
 type UserStateWithID struct {
-	StateID uint32
+	StateID int64
 	UserState
 }
 
 func MakeUserStateWithID(stateID uint32, userState *models.UserState) UserStateWithID {
 	return UserStateWithID{
-		StateID:   stateID,
+		StateID:   int64(stateID),
 		UserState: MakeUserState(userState),
+	}
+}
+
+func MakePendingUserStateWithID(userState *models.UserState) UserStateWithID {
+	return UserStateWithID{
+		StateID:   -1,
+		UserState: MakePendingUserState(userState),
 	}
 }
 
 func MakeUserState(userState *models.UserState) UserState {
 	return UserState{
-		PubKeyID: userState.PubKeyID,
+		PubKeyID: int64(userState.PubKeyID),
+		TokenID:  userState.TokenID,
+		Balance:  userState.Balance,
+		Nonce:    userState.Nonce,
+	}
+}
+
+func MakePendingUserState(userState *models.UserState) UserState {
+	maxUint32 := ^uint32(0)
+
+	var pubkeyToReturn int64
+	if userState.PubKeyID == maxUint32 {
+		pubkeyToReturn = -1
+	} else {
+		pubkeyToReturn = int64(userState.PubKeyID)
+	}
+
+	return UserState{
+		PubKeyID: pubkeyToReturn,
 		TokenID:  userState.TokenID,
 		Balance:  userState.Balance,
 		Nonce:    userState.Nonce,


### PR DESCRIPTION
This change is less likely to cause the mobile apps to crash, since they attempt to parse ints from our responses