### PR TITLE
Remco/hack prod

### DIFF
--- a/commander/batches.go
+++ b/commander/batches.go
@@ -106,14 +106,6 @@ func (c *Commander) syncRemoteBatch(ctx context.Context, remoteBatch eth.Decoded
 		attribute.String("hubble.batchHash", remoteBatch.GetBase().Hash.String()),
 		attribute.Int("hubble.commitmentCount", remoteBatch.GetCommitmentsLength()),
 	)
-	log.WithFields(log.Fields{
-		"batchID":         remoteBatch.GetBase().ID.Uint64(),
-		"batchType":       remoteBatch.GetBase().Type.String(),
-		"batchHash":       remoteBatch.GetBase().Hash.String(),
-		"commitmentCount": remoteBatch.GetCommitmentsLength(),
-		"accountRoot":     remoteBatch.GetBase().AccountTreeRoot.Hex(),
-	}).Debug("Syncing batch")
-
 	err := c.syncOrDisputeRemoteBatch(remoteBatch)
 	if errors.As(err, &icError) {
 		return c.replaceBatch(icError.LocalBatch, remoteBatch)

--- a/commander/batches.go
+++ b/commander/batches.go
@@ -106,6 +106,7 @@ func (c *Commander) syncRemoteBatch(ctx context.Context, remoteBatch eth.Decoded
 		attribute.String("hubble.batchHash", remoteBatch.GetBase().Hash.String()),
 		attribute.Int("hubble.commitmentCount", remoteBatch.GetCommitmentsLength()),
 	)
+
 	err := c.syncOrDisputeRemoteBatch(remoteBatch)
 	if errors.As(err, &icError) {
 		return c.replaceBatch(icError.LocalBatch, remoteBatch)

--- a/commander/batches.go
+++ b/commander/batches.go
@@ -106,6 +106,13 @@ func (c *Commander) syncRemoteBatch(ctx context.Context, remoteBatch eth.Decoded
 		attribute.String("hubble.batchHash", remoteBatch.GetBase().Hash.String()),
 		attribute.Int("hubble.commitmentCount", remoteBatch.GetCommitmentsLength()),
 	)
+	log.WithFields(log.Fields{
+		"batchID":         remoteBatch.GetBase().ID.Uint64(),
+		"batchType":       remoteBatch.GetBase().Type.String(),
+		"batchHash":       remoteBatch.GetBase().Hash.String(),
+		"commitmentCount": remoteBatch.GetCommitmentsLength(),
+		"accountRoot":     remoteBatch.GetBase().AccountTreeRoot.Hex(),
+	}).Debug("Syncing batch")
 
 	err := c.syncOrDisputeRemoteBatch(remoteBatch)
 	if errors.As(err, &icError) {

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -20,6 +20,8 @@ import (
 	"github.com/Worldcoin/hubble-commander/models/dto"
 	st "github.com/Worldcoin/hubble-commander/storage"
 	"github.com/Worldcoin/hubble-commander/tracing"
+	"github.com/Worldcoin/hubble-commander/utils"
+	"github.com/Worldcoin/hubble-commander/utils/merkletree"
 	"github.com/Worldcoin/hubble-commander/utils/ref"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/pkg/errors"
@@ -307,6 +309,16 @@ func setGenesisStateAndCreateClient(
 	if err != nil {
 		return nil, err
 	}
+	stateRoot, err := storage.StateTree.Root()
+	if err != nil {
+		return nil, err
+	}
+	zeroHash := merkletree.GetZeroHash(0) // TODO: Is this level zero for both?
+	commitmentRoot := utils.HashTwo(utils.HashTwo(*stateRoot, zeroHash), zeroHash)
+	log.WithFields(log.Fields{
+		"stateRoot":      stateRoot.Hex(),
+		"commitmentRoot": commitmentRoot.Hex(),
+	}).Info("Initialized storage with chain spec")
 
 	initialSyncedBlock := getInitialSyncedBlock(chainState.AccountRegistryDeploymentBlock)
 	err = storage.SetSyncedBlock(initialSyncedBlock)

--- a/commander/syncer/transaction_syncer.go
+++ b/commander/syncer/transaction_syncer.go
@@ -171,7 +171,10 @@ func (s *C2TSyncer) SetMissingTxsData(commitment encoder.Commitment, syncedTxs S
 		leaf, err := s.storage.AccountTree.Leaf(syncedTxs.PubKeyIDs()[i])
 		if err != nil {
 			if commitment.ToDecodedCommitment().ID.BatchID.CmpN(2022) == 0 || commitment.ToDecodedCommitment().ID.BatchID.CmpN(2024) == 0 {
-				// HACK: There are errors in blocks 2022 and 2024.
+				// HACK: There are errors in batches 2022 and 2024.
+				//       This might have happened because the eth transaction which registered these pubkeyids was dropped
+				//       Note that this means the affected Hubble accounts will not receive their airdrop, their money was instead
+				//       sent to the zero account.
 				log.WithFields(log.Fields{
 					"batchId":       commitment.ToDecodedCommitment().ID.BatchID,
 					"commitmentIdx": commitment.ToDecodedCommitment().ID.IndexInBatch,

--- a/commander/syncer/verify_signature.go
+++ b/commander/syncer/verify_signature.go
@@ -55,7 +55,7 @@ func (c *TxsContext) verifyCommitmentSignature(
 	}
 	if !isValid {
 		if commitment.ID.BatchID.CmpN(65) <= 0 {
-			// HACK: Signatures are screwed on the first 65 blocks.
+			// HACK: Signatures are screwed on the first 65 blocks. We just ignore this and continue processing.
 			log.WithFields(log.Fields{
 				"batchId": commitment.ID.BatchID,
 				"index":   commitment.ID.IndexInBatch,

--- a/commander/syncer/verify_signature.go
+++ b/commander/syncer/verify_signature.go
@@ -54,8 +54,8 @@ func (c *TxsContext) verifyCommitmentSignature(
 		return err
 	}
 	if !isValid {
-		if commitment.ID.BatchID.CmpN(65) <= 0 {
-			// HACK: Signatures are screwed on the first 65 blocks. We just ignore this and continue processing.
+		if commitment.ID.BatchID.CmpN(65) <= 0 || commitment.ID.BatchID.CmpN(2022) == 0 || commitment.ID.BatchID.CmpN(2024) == 0 {
+			// HACK: Signatures are screwed on the first 65 blocks and block 2022. We just ignore these and continue processing.
 			log.WithFields(log.Fields{
 				"batchId": commitment.ID.BatchID,
 				"index":   commitment.ID.IndexInBatch,

--- a/commander/syncer/verify_signature.go
+++ b/commander/syncer/verify_signature.go
@@ -54,7 +54,10 @@ func (c *TxsContext) verifyCommitmentSignature(
 		return err
 	}
 	if !isValid {
-		if commitment.ID.BatchID.CmpN(65) <= 0 || commitment.ID.BatchID.CmpN(2022) == 0 || commitment.ID.BatchID.CmpN(2024) == 0 {
+		shouldIgnoreFailure :=
+			c.cfg.HackSkipKnownBadSignatures &&
+				(commitment.ID.BatchID.CmpN(65) <= 0 || commitment.ID.BatchID.CmpN(2022) == 0 || commitment.ID.BatchID.CmpN(2024) == 0)
+		if shouldIgnoreFailure {
 			// HACK: Signatures are screwed on the first 65 blocks and block 2022. We just ignore these and continue processing.
 			log.WithFields(log.Fields{
 				"batchId": commitment.ID.BatchID,

--- a/commander/verify_commitment.go
+++ b/commander/verify_commitment.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Worldcoin/hubble-commander/utils"
 	"github.com/Worldcoin/hubble-commander/utils/merkletree"
 	"github.com/pkg/errors"
+	log "github.com/sirupsen/logrus"
 )
 
 var ErrInvalidCommitmentRoot = errors.New("invalid commitment root of batch #0")
@@ -21,8 +22,12 @@ func verifyCommitmentRoot(storage *st.Storage, client *eth.Client) error {
 		return err
 	}
 
-	zeroHash := merkletree.GetZeroHash(0)
+	zeroHash := merkletree.GetZeroHash(0) // TODO: Is this level zero for both?
 	commitmentRoot := utils.HashTwo(utils.HashTwo(*stateRoot, zeroHash), zeroHash)
+	log.WithFields(log.Fields{
+		"chainspec": commitmentRoot.Hex(),
+		"contract":  firstBatch.Hash.Hex(),
+	}).Info("Verifying genesis commitment root")
 	if firstBatch.Hash != commitmentRoot {
 		return ErrInvalidCommitmentRoot
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -54,6 +54,7 @@ func GetConfig() *Config {
 			StakeWithdrawalGasLimit:          getUint64("rollup.stake_withdrawal_gas_limit", DefaultStakeWithdrawalGasLimit),
 			BatchLoopInterval:                getDuration("rollup.batch_loop_interval", 500*time.Millisecond),
 			DisableSignatures:                getBool("rollup.disable_signatures", false),
+			HackSkipKnownBadSignatures:       getBool("hack.skip_known_bad_signatures", false),
 			MaxTxnDelay:                      getDuration("rollup.max_txn_delay", 30*time.Minute),
 		},
 		API: &APIConfig{
@@ -104,6 +105,7 @@ func GetTestConfig() *Config {
 			StakeWithdrawalGasLimit:          DefaultStakeWithdrawalGasLimit,
 			BatchLoopInterval:                500 * time.Millisecond,
 			DisableSignatures:                true,
+			HackSkipKnownBadSignatures:       false,
 			MaxTxnDelay:                      30 * time.Minute,
 		},
 		API: &APIConfig{

--- a/config/model.go
+++ b/config/model.go
@@ -79,6 +79,10 @@ type RollupConfig struct {
 	BatchLoopInterval                time.Duration
 	DisableSignatures                bool
 
+	// the current prod deployment has printed some bad batches and this flag triggers
+	// a hack to treat them as valid
+	HackSkipKnownBadSignatures bool
+
 	// if MinTxsPerCommitment or MinCommitmentsPerBatch cause a pending transaction to
 	// wait to be included for longer than this delay then they will be ignored and a
 	// new batch will be submitted

--- a/deploy/hubble/templates/statefulset.yaml
+++ b/deploy/hubble/templates/statefulset.yaml
@@ -105,6 +105,8 @@ spec:
               value: "20m"
             - name: HUBBLE_ROLLUP_BATCH_LOOP_INTERVAL
               value: "10m"
+            - name: HUBBLE_HACK_SKIP_KNOWN_BAD_SIGNATURES
+              value: "true"
             {{- else }}
             - name: HUBBLE_BOOTSTRAP_CHAIN_SPEC_PATH
               value: /config/chain-spec.yaml


### PR DESCRIPTION
* Disables signature validation when syncing for the first 65 blocks and {2022, 2024}.
* Substitutes pubkeyid 0 when the c2ts in block 2022, 2024 don't have one associated.
* Adds more log output