### PR TITLE
Set Kubernetes resource values

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -215,10 +215,8 @@ jobs:
         run: helm upgrade "${{ github.event.repository.name }}" ./deploy/hubble
           --install --atomic --timeout 60s
           --namespace "${{ github.event.repository.name }}"
+          --values ./deploy/hubble/values-stage.yaml
           --set image.tag="${{ github.sha }}"
-          --set ingress.host=hubble.stage-crypto.worldcoin.dev
-          --set environment=stage
-          --set persistentStorage.volumeID=aws://us-east-1a/vol-065fd87c2124454e6
   deploy-stage-hubble-instances-manual:
     runs-on: ubuntu-latest
     needs: [ build-and-push ]
@@ -243,10 +241,8 @@ jobs:
         run: helm upgrade "${{ github.event.repository.name }}" ./deploy/hubble
           --install
           --namespace "${{ github.event.repository.name }}"
+          --values ./deploy/hubble/values-stage.yaml
           --set image.tag="${{ github.sha }}"
-          --set ingress.host=hubble.stage-crypto.worldcoin.dev
-          --set environment=stage
-          --set persistentStorage.volumeID=aws://us-east-1a/vol-065fd87c2124454e6
   deploy-prod:
     runs-on: ubuntu-latest
     needs: [ build-and-push, e2e-tests ]

--- a/deploy/hubble/values-stage.yaml
+++ b/deploy/hubble/values-stage.yaml
@@ -1,0 +1,18 @@
+environment: stage
+
+ingress:
+  host: "hubble.stage-crypto.worldcoin.dev"
+
+resources:
+  limits:
+    cpu: 4
+    memory: 6Gi
+  requests:
+    cpu: 3
+    memory: 4Gi
+
+persistentStorage:
+  size: 100Gi
+  volumeID: aws://us-east-1a/vol-065fd87c2124454e6 # example: aws://us-east-1c/vol-aabbcc123
+
+wipeDisk: false

--- a/deploy/hubble/values.yaml
+++ b/deploy/hubble/values.yaml
@@ -35,10 +35,10 @@ ingress:
 resources:
   limits:
     cpu: 14
-    memory: 30Gi
+    memory: 8Gi
   requests:
-    cpu: 8
-    memory: 25Gi
+    cpu: 3
+    memory: 5Gi
 
 nameOverride: ""
 fullnameOverride: ""

--- a/deploy/hubble/values.yaml
+++ b/deploy/hubble/values.yaml
@@ -32,17 +32,13 @@ service:
 ingress:
   host: "hubble.crypto.worldcoin.dev"
 
-resources: {}
-  # We usually recommend not to specify default resources and to leave this as a conscious
-  # choice for the user. This also increases chances charts run on environments with little
-  # resources, such as Minikube. If you do want to specify resources, uncomment the following
-  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
-  # limits:
-  #   cpu: 100m
-  #   memory: 128Mi
-  # requests:
-  #   cpu: 100m
-  #   memory: 128Mi
+resources:
+  limits:
+    cpu: 14
+    memory: 30Gi
+  requests:
+    cpu: 8
+    memory: 25Gi
 
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
Requests and limits are the mechanisms Kubernetes uses to control resources such as CPU and memory. Requests are what the container is guaranteed to get. If a container requests a resource, Kubernetes will only schedule it on a node that can give it that resource. Limits, on the other hand, make sure a container never goes above a certain value.

Production resources were set based on the current configuration running on the cluster.

Additionally, I move all stage values to a separate values file. The change can be checked using 
```
helm upgrade hubble-commander ./deploy/hubble --install --namespace hubble-commander --values ./deploy/hubble/values-stage.yaml --debug --dry-run
```

Update Aug 30, change production resources after we stabilize the service
![Screenshot 2022-08-29 at 18 06 44](https://user-images.githubusercontent.com/2135758/187377916-f19a26c4-309b-48ac-80dc-c517f3b2b0df.png)

