### PR TITLE
Golangci lint fixes

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -15,8 +15,8 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:
-          version: v1.45.2
-          args: --timeout 5m --build-tags hardhat,e2e
+          version: v1.49.0
+          args: --timeout 7m --build-tags hardhat,e2e
           skip-build-cache: true
           skip-pkg-cache: true
   test-on-hardhat:

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -47,7 +47,6 @@ linters:
   disable-all: true
   enable:
     - bodyclose
-    - deadcode
     - depguard
     - dogsled
     - errcheck
@@ -69,13 +68,11 @@ linters:
     - rowserrcheck
     - exportloopref
     - staticcheck
-    - structcheck
     - stylecheck
     - typecheck
     - unconvert
     - unparam
     - unused
-    - varcheck
     - whitespace
     - gci
     - durationcheck

--- a/api/api.go
+++ b/api/api.go
@@ -3,6 +3,7 @@ package api
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/Worldcoin/hubble-commander/api/admin"
 	"github.com/Worldcoin/hubble-commander/api/middleware"
@@ -73,7 +74,11 @@ func NewServer(
 	}))
 
 	addr := fmt.Sprintf(":%s", cfg.API.Port)
-	return &http.Server{Addr: addr, Handler: mux}, nil
+	return &http.Server{
+		ReadHeaderTimeout: time.Second * 5,
+		Addr:              addr,
+		Handler:           mux,
+	}, nil
 }
 
 func NewTestAPI(

--- a/api/api_test.go
+++ b/api/api_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 type Result struct {
-	// nolint:revive,stylecheck
+	//nolint:revive,stylecheck
 	JsonRpc string `json:"jsonrpc"`
 	ID      string `json:"id"`
 	Result  string `json:"result"`

--- a/api/calculate_transfer_status_test.go
+++ b/api/calculate_transfer_status_test.go
@@ -118,7 +118,7 @@ func (s *CalculateTransactionStatusTestSuite) TestCalculateTransactionStatus_InB
 	s.Equal(txstatus.Mined, *status)
 }
 
-// nolint:misspell
+//nolint:misspell
 func (s *CalculateTransactionStatusTestSuite) TestCalculateTransactionStatus_Finalised() {
 	currentBlockNumber, err := s.sim.GetLatestBlockNumber()
 	s.NoError(err)

--- a/api/rpc/server_test.go
+++ b/api/rpc/server_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 type Result struct {
-	// nolint:revive,stylecheck
+	//nolint:revive,stylecheck
 	JsonRpc string      `json:"jsonrpc"`
 	ID      string      `json:"id"`
 	Result  interface{} `json:"result"`

--- a/commander/applier/apply_tx.go
+++ b/commander/applier/apply_tx.go
@@ -144,7 +144,7 @@ func validateTxNonce(senderState *models.UserState, txNonce models.Uint256) erro
 }
 
 func calculateStateAfterTx(
-	senderState, receiverState models.UserState, // nolint:gocritic
+	senderState, receiverState models.UserState, //nolint:gocritic
 	tx models.GenericTransaction,
 ) (
 	newSenderState, newReceiverState *models.UserState,
@@ -171,7 +171,7 @@ func calculateStateAfterTx(
 }
 
 func calculateSenderStateAfterTx(
-	senderState models.UserState, // nolint:gocritic
+	senderState models.UserState, //nolint:gocritic
 	tx models.GenericTransaction,
 ) (newSenderState *models.UserState, err error) {
 	fee := tx.GetFee()
@@ -195,7 +195,7 @@ func calculateSenderStateAfterTx(
 }
 
 func calculateReceiverStateAfterTx(
-	receiverState models.UserState, // nolint:gocritic
+	receiverState models.UserState, //nolint:gocritic
 	tx models.GenericTransaction,
 ) *models.UserState {
 	amount := tx.GetAmount()

--- a/commander/executor/execution_context.go
+++ b/commander/executor/execution_context.go
@@ -59,7 +59,7 @@ func (c *ExecutionContext) Commit() error {
 	return c.tx.Commit()
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (c *ExecutionContext) Rollback(cause *error) {
 	c.tx.Rollback(cause)
 }

--- a/commander/lifecycle.go
+++ b/commander/lifecycle.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 )
 
-// nolint:structcheck
+//nolint:structcheck
 type lifecycle struct {
 	mutex            sync.Mutex // protects Start method and startAndWaitChan
 	startAndWaitChan chan struct{}

--- a/commander/rollup_controls.go
+++ b/commander/rollup_controls.go
@@ -5,7 +5,7 @@ import (
 	"sync/atomic"
 )
 
-// nolint:structcheck
+//nolint:structcheck
 type rollupControls struct {
 	batchCreationEnabled bool
 	migrate              uint32

--- a/commander/syncer/context.go
+++ b/commander/syncer/context.go
@@ -69,7 +69,7 @@ func (c *Context) Commit() error {
 	return c.tx.Commit()
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (c *Context) Rollback(cause *error) {
 	c.tx.Rollback(cause)
 }

--- a/commander/txs_batches_test.go
+++ b/commander/txs_batches_test.go
@@ -417,8 +417,9 @@ func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_DisputesBatchWithInvalidTokenA
 }
 
 // TODO: what is this test testing? It claims to confirm we can send to
-//       nonexistent receivers but why would that be okay? And we call a method
-//       which creates the receiver(!) before doing anything.
+//
+//	nonexistent receivers but why would that be okay? And we call a method
+//	which creates the receiver(!) before doing anything.
 func (s *TxsBatchesTestSuite) TestSyncRemoteBatch_AllowsTransferToNonexistentReceiver() {
 	tx := s.submitTransferToNonexistentReceiver()
 

--- a/config/deploy_config.go
+++ b/config/deploy_config.go
@@ -15,7 +15,7 @@ func GetDeployerConfig() *DeployerConfig {
 
 	return &DeployerConfig{
 		Bootstrap: &DeployerBootstrapConfig{
-			BlocksToFinalise: getUint32("bootstrap.blocks_to_finalise", DefaultBlocksToFinalise), // nolint:misspell
+			BlocksToFinalise: getUint32("bootstrap.blocks_to_finalise", DefaultBlocksToFinalise), //nolint:misspell
 			GenesisAccounts:  getGenesisAccounts(),
 			Chooser:          getAddressOrNil("chooser_address"),
 		},

--- a/config/get_viper.go
+++ b/config/get_viper.go
@@ -57,7 +57,7 @@ func getUint64OrPanic(key string) uint64 {
 	return value
 }
 
-// nolint: unparam
+//nolint:unparam
 func getBool(key string, fallback bool) bool {
 	viper.SetDefault(key, fallback)
 	return viper.GetBool(key)

--- a/db/encoder.go
+++ b/db/encoder.go
@@ -12,9 +12,10 @@ import (
 
 var errPassedByPointer = fmt.Errorf("pointer was passed to Encode, pass by value instead")
 
-// nolint:gocyclo, funlen
 // Encode Remember to provide cases for both value and pointer types when adding new encoders
 // TODO shorten this function by using ByteEncoder interface
+//
+//nolint:gocyclo, funlen
 func Encode(value interface{}) ([]byte, error) {
 	switch v := value.(type) {
 	case models.AccountNode:
@@ -130,7 +131,7 @@ func Encode(value interface{}) ([]byte, error) {
 	}
 }
 
-// nolint:gocyclo, funlen
+//nolint:gocyclo, funlen
 func Decode(data []byte, value interface{}) error {
 	switch v := value.(type) {
 	case *models.AccountNode:
@@ -198,7 +199,7 @@ func Decode(data []byte, value interface{}) error {
 	}
 }
 
-// nolint: gocritic
+//nolint:gocritic
 func decodeHashPointer(data []byte, value *interface{}, dst *common.Hash) error {
 	if len(data) == 32 {
 		return stored.DecodeHash(data, dst)
@@ -210,7 +211,7 @@ func decodeHashPointer(data []byte, value *interface{}, dst *common.Hash) error 
 	return nil
 }
 
-// nolint: gocritic
+//nolint:gocritic
 func decodeUint32Pointer(data []byte, value *interface{}, dst *uint32) error {
 	if len(data) == 4 {
 		return stored.DecodeUint32(data, dst)

--- a/db/tx_controller.go
+++ b/db/tx_controller.go
@@ -20,7 +20,7 @@ func NewTxController(tx rawController, isLocked bool) *TxController {
 	return &TxController{tx, isLocked}
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (t *TxController) Rollback(cause *error) {
 	if !t.isLocked {
 		t.isLocked = true

--- a/encoder/batch.go
+++ b/encoder/batch.go
@@ -10,11 +10,12 @@ import (
 )
 
 // DecodeTransferBatchCalldata
-//   uint256 batchID
-//   bytes32[] stateRoots,
-//   uint256[2][] signatures,
-//   uint256[] feeReceivers,
-//   bytes[] txss
+//
+//	uint256 batchID
+//	bytes32[] stateRoots,
+//	uint256[2][] signatures,
+//	uint256[] feeReceivers,
+//	bytes[] txss
 func DecodeTransferBatchCalldata(rollupABI *abi.ABI, calldata []byte) ([]DecodedCommitment, error) {
 	unpacked, err := rollupABI.Methods["submitTransfer"].Inputs.Unpack(calldata[4:])
 	if err != nil {
@@ -47,12 +48,13 @@ func DecodeTransferBatchCalldata(rollupABI *abi.ABI, calldata []byte) ([]Decoded
 }
 
 // DecodeMMBatchCalldata
-//	 uint256 batchID,
-//	 bytes32[] stateRoots,
-//	 uint256[2][] signatures,
-//	 uint256[4][] meta,
-//	 bytes32[] withdrawRoots,
-//	 bytes[] txss
+//
+//	uint256 batchID,
+//	bytes32[] stateRoots,
+//	uint256[2][] signatures,
+//	uint256[4][] meta,
+//	bytes32[] withdrawRoots,
+//	bytes[] txss
 func DecodeMMBatchCalldata(rollupABI *abi.ABI, calldata []byte) ([]DecodedMMCommitment, error) {
 	unpacked, err := rollupABI.Methods["submitMassMigration"].Inputs.Unpack(calldata[4:])
 	if err != nil {

--- a/eth/deployer/rollup/rollup.go
+++ b/eth/deployer/rollup/rollup.go
@@ -98,7 +98,7 @@ func DeployRollup(c chain.ManualNonceConnection) (*RollupContracts, error) {
 	return DeployConfiguredRollup(c, &DeploymentConfig{})
 }
 
-// nolint:funlen,gocyclo
+//nolint:funlen,gocyclo
 func DeployConfiguredRollup(c chain.ManualNonceConnection, cfg *DeploymentConfig) (*RollupContracts, error) {
 	fillWithDefaults(&cfg.Params)
 

--- a/eth/session_builder.go
+++ b/eth/session_builder.go
@@ -1,4 +1,4 @@
-// nolint: gocritic
+//nolint:gocritic
 package eth
 
 import (

--- a/metrics/server.go
+++ b/metrics/server.go
@@ -3,6 +3,7 @@ package metrics
 import (
 	"fmt"
 	"net/http"
+	"time"
 
 	"github.com/Worldcoin/hubble-commander/config"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
@@ -15,5 +16,9 @@ func (c *CommanderMetrics) NewServer(cfg *config.MetricsConfig) *http.Server {
 	mux.Handle(cfg.Endpoint, handler)
 
 	addr := fmt.Sprintf(":%s", cfg.Port)
-	return &http.Server{Addr: addr, Handler: mux}
+	return &http.Server{
+		ReadHeaderTimeout: time.Second * 5,
+		Addr:              addr,
+		Handler:           mux,
+	}
 }

--- a/models/account.go
+++ b/models/account.go
@@ -25,16 +25,18 @@ type AccountNode struct {
 	DataHash   common.Hash
 }
 
-// nolint:gocritic
 // Type implements badgerhold.Storer
+//
+//nolint:gocritic
 func (a AccountLeaf) Type() string {
 	return string(AccountLeafName)
 }
 
-// nolint:gocritic
 // Indexes implements badgerhold.Storer
 // We're adding a lot of Accounts with ZeroPublicKey to the database as a result of the way C2T processing is currently implemented.
 // See the usages of ZeroPublicKey for more context.
+//
+//nolint:gocritic
 func (a AccountLeaf) Indexes() map[string]bh.Index {
 	return map[string]bh.Index{
 		"PublicKey": {

--- a/models/create2transfer.go
+++ b/models/create2transfer.go
@@ -34,12 +34,12 @@ func (t *Create2Transfer) ToMassMigration() *MassMigration {
 	panic("Create2Transfer cannot be cast to MassMigration")
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (t Create2Transfer) Copy() GenericTransaction {
 	return &t
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (t Create2Transfer) Clone() *Create2Transfer {
 	return &t
 }

--- a/models/enums/batchstatus/batch_status.go
+++ b/models/enums/batchstatus/batch_status.go
@@ -11,13 +11,13 @@ type BatchStatus uint
 const (
 	Submitted BatchStatus = iota + 1
 	Mined
-	Finalised // nolint:misspell
+	Finalised //nolint:misspell
 )
 
 var BatchStatuses = map[BatchStatus]string{
 	Submitted: "SUBMITTED",
 	Mined:     "MINED",
-	Finalised: "FINALISED", // nolint:misspell
+	Finalised: "FINALISED", //nolint:misspell
 }
 
 func (s BatchStatus) Ref() *BatchStatus {

--- a/models/enums/txstatus/transaction_status.go
+++ b/models/enums/txstatus/transaction_status.go
@@ -13,7 +13,7 @@ const (
 	Pending   = TransactionStatus(0)
 	Submitted = TransactionStatus(bs.Submitted)
 	Mined     = TransactionStatus(bs.Mined)
-	Finalised = TransactionStatus(bs.Finalised) // nolint:misspell
+	Finalised = TransactionStatus(bs.Finalised) //nolint:misspell
 	Error     = TransactionStatus(4)
 )
 
@@ -21,7 +21,7 @@ var TransactionStatuses = map[TransactionStatus]string{
 	Pending:   "PENDING",
 	Submitted: bs.BatchStatuses[bs.Submitted],
 	Mined:     bs.BatchStatuses[bs.Mined],
-	Finalised: bs.BatchStatuses[bs.Finalised], // nolint:misspell
+	Finalised: bs.BatchStatuses[bs.Finalised], //nolint:misspell
 	Error:     "ERROR",
 }
 

--- a/models/mass_migration.go
+++ b/models/mass_migration.go
@@ -33,7 +33,7 @@ func (m *MassMigration) ToMassMigration() *MassMigration {
 	return m
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (m MassMigration) Copy() GenericTransaction {
 	return &m
 }

--- a/models/public_key.go
+++ b/models/public_key.go
@@ -28,7 +28,7 @@ func MakePublicKeyFromInts(ints [4]*big.Int) PublicKey {
 	return publicKey
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (p PublicKey) Bytes() []byte {
 	return p[:]
 }
@@ -76,7 +76,7 @@ func (p *PublicKey) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	return err
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (p PublicKey) MarshalText() ([]byte, error) {
 	return hexutil.Bytes(p[:]).MarshalText()
 }

--- a/models/state.go
+++ b/models/state.go
@@ -57,7 +57,7 @@ type StateUpdate struct {
 	PrevStateLeaf StateLeaf
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (s UserState) Copy() *UserState {
 	return &s
 }

--- a/models/stored/batched_tx.go
+++ b/models/stored/batched_tx.go
@@ -72,8 +72,9 @@ func (t *BatchedTx) ToMassMigration() *models.MassMigration {
 }
 
 // Careful: If there is a failure this will leave behind a partially-
-//          populated PendinTx. If this gives you an error throw away the
-//          PendingTx!
+//
+//	populated PendinTx. If this gives you an error throw away the
+//	PendingTx!
 func (t *BatchedTx) SetBytes(data []byte) error {
 	if len(data) < sizeBatchedTxNoBody {
 		// This prevents obvious errors but it is still possible for this []byte
@@ -98,14 +99,16 @@ func (t *BatchedTx) BytesLen() int {
 	return t.PendingTx.BytesLen() + sizeCommitmentSlot
 }
 
-// nolint:gocritic
 // Type implements badgerhold.Storer
+//
+//nolint:gocritic
 func (t BatchedTx) Type() string {
 	return string(BatchedTxName)
 }
 
-// nolint:gocritic
 // Indexes implements badgerhold.Storer
+//
+//nolint:gocritic
 func (t BatchedTx) Indexes() map[string]bh.Index {
 	return map[string]bh.Index{
 		"Hash": {

--- a/models/stored/failed_tx.go
+++ b/models/stored/failed_tx.go
@@ -81,14 +81,16 @@ func (t *FailedTx) BytesLen() int {
 	return t.PendingTx.BytesLen() + len(t.ErrorMessage)
 }
 
-// nolint:gocritic
 // Type implements badgerhold.Storer
+//
+//nolint:gocritic
 func (t FailedTx) Type() string {
 	return string(FailedTxName)
 }
 
-// nolint:gocritic
 // Indexes implements badgerhold.Storer
+//
+//nolint:gocritic
 func (t FailedTx) Indexes() map[string]bh.Index {
 	return map[string]bh.Index{
 		"FromStateID:Nonce": {

--- a/models/stored/pending_tx.go
+++ b/models/stored/pending_tx.go
@@ -96,8 +96,9 @@ func takeSlice(data []byte, count int) (slice, rest []byte) {
 }
 
 // Careful: If there is a failure this will leave behind a partially-
-//          populated PendinTx. If this gives you an error throw away the
-//          PendingTx!
+//
+//	populated PendinTx. If this gives you an error throw away the
+//	PendingTx!
 func (t *PendingTx) SetBytes(data []byte) error {
 	if len(data) < sizePendingTxNoBody {
 		return models.ErrInvalidLength

--- a/models/stored/pending_tx_test.go
+++ b/models/stored/pending_tx_test.go
@@ -13,7 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// nolint:gocritic
+//nolint:gocritic
 func (t PendingTx) Generate(rand *rand.Rand, size int) reflect.Value {
 	hashBytes := make([]byte, 32)
 	rand.Read(hashBytes)
@@ -51,7 +51,7 @@ func TestPendingTx_BytesLenMatchesBytes(t *testing.T) {
 	f := func() bool {
 		valuePendingTx, ok := quick.Value(
 			reflect.TypeOf(PendingTx{}),
-			// nolint:gosec
+			//nolint:gosec
 			rand.New(rand.NewSource(time.Now().Unix())),
 		)
 		require.True(t, ok)

--- a/models/transfer.go
+++ b/models/transfer.go
@@ -33,7 +33,7 @@ func (t *Transfer) ToMassMigration() *MassMigration {
 	panic("Transfer cannot be cast to MassMigration")
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (t Transfer) Copy() GenericTransaction {
 	return &t
 }

--- a/storage/initialize_index.go
+++ b/storage/initialize_index.go
@@ -13,8 +13,9 @@ import (
 // If you don't index nil values the way we did for stored.TxReceipt.ToStateID it can be the case that there is some
 // stored.TxReceipt stored, but there is no index entry. To work around this we set an empty index entry.
 // See:
-// 	 * stored.TxReceipt Indexes() method
-//   * InitializeIndexTestSuite.TestStoredTxReceipt_ToStateID_FindUsingIndexWorksWhenThereAreOnlyValuesWithThisFieldSetToNil
+//   - stored.TxReceipt Indexes() method
+//   - InitializeIndexTestSuite.TestStoredTxReceipt_ToStateID_FindUsingIndexWorksWhenThereAreOnlyValuesWithThisFieldSetToNil
+//
 // Note, this does not create the index. In order to create the index we must implement
 // Indexes() on the relevant type.
 func initializeIndex(database *Database, typeName []byte, indexName string, zeroValue interface{}) error {

--- a/storage/mempool.go
+++ b/storage/mempool.go
@@ -232,7 +232,8 @@ func (s *Storage) GetPendingUserStates(pubkey *models.PublicKey) ([]models.UserS
 }
 
 // TODO: this assumes the sender & receiver stateIDs are in the state tree,
-//       make sure all callers check for this? Maybe return a nice error?
+//
+//	make sure all callers check for this? Maybe return a nice error?
 func (s *Storage) AddMempoolTx(tx models.GenericTransaction) error {
 	// TODO: should we check that this txn does not already exist as a batchedTx?
 	// TODO: should this accept a stored.PendingTx, so we do not accidentally accept
@@ -250,9 +251,9 @@ func (s *Storage) AddMempoolTx(tx models.GenericTransaction) error {
 	})
 }
 
-// - assumes we are currently inside a transaction
-// - checks that the txn cleanly applies to the pending state but assumes all other
-//   validation has already been done (e.g. the signature check)
+//   - assumes we are currently inside a transaction
+//   - checks that the txn cleanly applies to the pending state but assumes all other
+//     validation has already been done (e.g. the signature check)
 func (s *Storage) unsafeAddMempoolTx(tx models.GenericTransaction) error {
 	// (I) Validate the txn against the pending state
 
@@ -438,7 +439,9 @@ func itemToPendingTx(item *badger.Item) (*stored.PendingTx, error) {
 }
 
 // TODO: I know the mempool is small but does it really make sense to scan the entire
-//       thing every loop?
+//
+//	thing every loop?
+//
 // TODO: add a test for this method, lint showed me a bug in it
 func (s *Storage) FindOldestMempoolTransaction(txType txtype.TransactionType) (*stored.PendingTx, error) {
 	pendingTxs, err := s.lowestNoncePendingTxs()
@@ -543,8 +546,9 @@ func (s *Storage) forEachMempoolTransaction(fun func(*stored.PendingTx) error) e
 // This assumes that the mempool is relatively small, but we don't do anything to
 // guarantee that the mempool remains small.
 // TODO: Add some metrics which will warn us if this method (or its callers) start taking
-//       too long, and we can add some restrictions on how many pending trasnactions each
-//       account is allowed to have... or add an index
+//
+//	too long, and we can add some restrictions on how many pending trasnactions each
+//	account is allowed to have... or add an index
 func (s *Storage) GetMempoolTransactionByHash(hash common.Hash) (*stored.PendingTx, error) {
 	allPendingTxs, err := s.GetAllMempoolTransactions()
 	if err != nil {
@@ -852,7 +856,9 @@ func (mh *MempoolHeap) pushTx(tx *stored.PendingTx) {
 }
 
 // Caution: assumes the pendingTx which we are about to drop has been applied to the state
-//          in mh.storage
+//
+//	in mh.storage
+//
 //nolint:gocyclo  // TODO: consider doing what it says
 func (mh *MempoolHeap) DropHighestFeeExecutableTx() error {
 	pendingTx := mh.heap.Pop()

--- a/storage/mempool_test.go
+++ b/storage/mempool_test.go
@@ -64,7 +64,8 @@ func (s *MempoolTestSuite) TearDownTest() {
 }
 
 // TODO: this should not be a unit test, this test belongs on the api/ directory
-//       the api test will test the exact same thing but make the code less brittle
+//
+//	the api test will test the exact same thing but make the code less brittle
 func (s *MempoolTestSuite) TestMempool_UsesPendingBalance() {
 	// stateID=2 starts with Balance=0, so the API does not accept any transfers
 	// from it until it receives some money

--- a/storage/stored_transaction.go
+++ b/storage/stored_transaction.go
@@ -194,7 +194,7 @@ func (s *Storage) initBatchedTxsCounter() (err error) {
 func (s *TransactionStorage) getTransactionIDsByBatchID(batchID models.Uint256) ([]models.CommitmentSlot, error) {
 	slots := make([]models.CommitmentSlot, 0, 32)
 
-	// nolint: gocritic
+	//nolint: gocritic
 	seekPrefix := append(stored.BatchedTxPrefix, batchID.Bytes()...)
 
 	// BatchedTx are stored with CommitmentSlot as their primary key: BatchID is the
@@ -236,7 +236,8 @@ func (s *TransactionStorage) GetTransactionIDsByBatchIDs(batchIDs ...models.Uint
 }
 
 // TODO: can all our callers just call Storage.GetAllMempoolTransactions()
-//       they sure can, this is only called by the test suite
+//
+//	they sure can, this is only called by the test suite
 func (s *TransactionStorage) GetPendingTransactions(txType txtype.TransactionType) (models.GenericArray, error) {
 	pendingTxs, err := s.tsGetAllMempoolTransactions()
 	if err != nil {

--- a/storage/transaction.go
+++ b/storage/transaction.go
@@ -61,7 +61,7 @@ func (s *TransactionStorage) GetTransactionsByCommitmentID(id models.CommitmentI
 	// serialization of the CommitmentSlot. This makes it easy to look for all
 	// BatchedTxs for `id`
 
-	// nolint: gocritic
+	//nolint: gocritic
 	seekPrefix := append(stored.BatchedTxPrefix, id.Bytes()...)
 
 	err := s.database.Badger.Iterator(seekPrefix, db.PrefetchIteratorOpts, func(item *bdg.Item) (bool, error) {
@@ -187,8 +187,9 @@ func (s *TransactionStorage) BatchAddTransaction(txs models.GenericTransactionAr
 }
 
 // TODO: This needs to be fixed.
-//       It used to take pending/failed transactions and add them to batches (as a result
-//       of the sync process.
+//
+//	It used to take pending/failed transactions and add them to batches (as a result
+//	of the sync process.
 func (s *TransactionStorage) BatchUpsertTransaction(txs models.GenericTransactionArray) error {
 	if txs.Len() < 1 {
 		return errors.WithStack(ErrNoRowsAffected)

--- a/testutils/simulator/backend.go
+++ b/testutils/simulator/backend.go
@@ -16,7 +16,7 @@ func NewBackend(simulatedBackend *backends.SimulatedBackend) *Backend {
 	return &Backend{SimulatedBackend: simulatedBackend}
 }
 
-// nolint:gocritic
+//nolint:gocritic
 func (b *Backend) CallContract(ctx context.Context, call ethereum.CallMsg, _ *big.Int) ([]byte, error) {
 	return b.SimulatedBackend.CallContract(ctx, call, nil)
 }

--- a/utils/project_root.go
+++ b/utils/project_root.go
@@ -7,7 +7,7 @@ import (
 )
 
 func GetProjectRoot() string {
-	_, file, _, _ := runtime.Caller(0) // nolint:dogsled
+	_, file, _, _ := runtime.Caller(0) //nolint:dogsled
 	fileDir := filepath.Dir(file)
 	return path.Join(fileDir, "..")
 }

--- a/utils/random.go
+++ b/utils/random.go
@@ -10,7 +10,7 @@ import (
 
 func RandomBytes(size uint64) []byte {
 	bytes := make([]byte, size)
-	// nolint:gosec
+	//nolint:gosec
 	rand.Read(bytes)
 	return bytes
 }
@@ -33,6 +33,6 @@ func RandomAddress() common.Address {
 }
 
 func RandomBigInt() *big.Int {
-	// nolint:gosec
+	//nolint:gosec
 	return new(big.Int).SetUint64(rand.Uint64())
 }


### PR DESCRIPTION
I wanted to merge https://github.com/worldcoin/hubble-commander/pull/662 but CI breaks on linter so this PR should fix those errors.

c55d96e6945389853f6c0bde011739c9a97ffa5c This fix G112: Potential Slowloris Attack because ReadHeaderTimeout is not configured in the http.Server GoSec issue. A short article about it can be found [here.](https://medium.com/a-journey-with-go/go-understand-and-mitigate-slowloris-attack-711c1b1403f6)