### PR TITLE
Add SafeMode

### DIFF
--- a/commander/commander.go
+++ b/commander/commander.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/Worldcoin/hubble-commander/api"
 	"github.com/Worldcoin/hubble-commander/commander/tracker"
@@ -149,9 +150,16 @@ func (c *Commander) Start() (err error) {
 		}()
 	}
 
-	c.startWorker("Tracking Sent Txs", func() error { return c.txsTracker.TrackSentTxs(c.workersContext) })
-	c.startWorker("Sending Requested Txs", func() error { return c.txsTracker.SendRequestedTxs(c.workersContext) })
-	c.startWorker("New Block Loop", func() error { return c.newBlockLoop() })
+	if c.cfg.SafeMode {
+		log.Warn("Commander running in safe mode, most functions are disabled")
+	} else {
+		c.startWorker("Tracking Sent Txs", func() error { return c.txsTracker.TrackSentTxs(c.workersContext) })
+		c.startWorker("Sending Requested Txs", func() error { return c.txsTracker.SendRequestedTxs(c.workersContext) })
+		c.startWorker("New Block Loop", func() error { return c.newBlockLoop() })
+	}
+
+	c.startWorker("Mempool Metrics", func() error { return c.mempoolMetricsLoop() })
+	c.startWorker("Badger Garbage Colection", func() error { return c.badgerGCLoop() })
 
 	go c.handleWorkerError()
 
@@ -179,6 +187,45 @@ func (c *Commander) EnableBatchCreation(enable bool) {
 	c.batchCreationEnabled = enable
 	if !enable {
 		c.stopRollupLoop()
+	}
+}
+
+func (c *Commander) mempoolMetricsLoop() error {
+	ticker := time.NewTicker(time.Second * 10)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.workersContext.Done():
+			return nil
+		case <-ticker.C:
+			err := c.updateMempoolMetrics()
+			if err != nil {
+				return err
+			}
+		}
+	}
+}
+
+func (c *Commander) badgerGCLoop() error {
+	ticker := time.NewTicker(time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.workersContext.Done():
+			return nil
+		case <-ticker.C:
+			log.Debug("Running GC in background")
+		again:
+			innerErr := c.storage.TriggerGC()
+			if innerErr == nil {
+				goto again
+			}
+			// this looks weird but we're ignoring the error because innerErr!=nil
+			// _if we successfully did nothing_
+			log.Debug("Finished Running GC: ", innerErr)
+		}
 	}
 }
 

--- a/commander/new_block.go
+++ b/commander/new_block.go
@@ -49,7 +49,7 @@ func (c *Commander) newBlockLoop() error {
 				log.WithFields(log.Fields{
 					"RemoteBlock": currentBlock.Number.Uint64(),
 					"LocalBlock":  c.storage.GetLatestBlockNumber(),
-				}).Warn("Possible unhandled reorg: recived an old block")
+				}).Warn("Possible unhandled reorg: received an old block")
 				continue
 			}
 

--- a/commander/rollup.go
+++ b/commander/rollup.go
@@ -51,9 +51,6 @@ func (c *Commander) rollupLoop(ctx context.Context) (err error) {
 	ticker := time.NewTicker(c.cfg.Rollup.BatchLoopInterval)
 	defer ticker.Stop()
 
-	updateMempoolTicker := time.NewTicker(time.Second * 10)
-	defer updateMempoolTicker.Stop()
-
 	currentBatchType := batchtype.Transfer
 
 	for {
@@ -62,13 +59,6 @@ func (c *Commander) rollupLoop(ctx context.Context) (err error) {
 			return nil
 		case <-ticker.C:
 			err = c.rollupLoopIteration(ctx, &currentBatchType)
-			if err != nil {
-				return err
-			}
-		case <-updateMempoolTicker.C:
-			// TODO: a long rollupLoopIteration can starve this metric,
-			//       create a separate worker
-			err := c.updateMempoolMetrics()
 			if err != nil {
 				return err
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -67,6 +67,7 @@ func GetConfig() *Config {
 			Path: getString("badger.path", "./db/data/hubble"),
 		},
 		Ethereum: getEthereumConfig(),
+		SafeMode: getBool("safe_mode", false),
 	}
 }
 
@@ -126,6 +127,7 @@ func GetTestConfig() *Config {
 		Tracing: &TracingConfig{
 			Enabled: false,
 		},
+		SafeMode: false,
 	}
 }
 

--- a/config/model.go
+++ b/config/model.go
@@ -22,6 +22,12 @@ type Config struct {
 	API       *APIConfig
 	Badger    *BadgerConfig
 	Ethereum  *EthereumConfig
+
+	// Hubble is not yet stable but a lot of services rely on the commander being available
+	// at all times. When SafeMode=true Hubble only serves API requests, it does not attempt
+	// to create batches or sync against the chain.
+	// export HUBBLE_SAFE_MODE=true
+	SafeMode bool
 }
 
 type LogConfig struct {

--- a/deploy/hubble/templates/statefulset.yaml
+++ b/deploy/hubble/templates/statefulset.yaml
@@ -107,6 +107,8 @@ spec:
               value: "10m"
             - name: HUBBLE_HACK_SKIP_KNOWN_BAD_SIGNATURES
               value: "true"
+            - name: HUBBLE_SAFE_MODE
+              value: "true"
             {{- else }}
             - name: HUBBLE_BOOTSTRAP_CHAIN_SPEC_PATH
               value: /config/chain-spec.yaml


### PR DESCRIPTION
`export HUBBLE_SAFE_MODE=true` will cause Hubble to only start the API and some background workers. It will not attempt to create batches or sync against the main chain.