### PR TITLE
Add additional domain for hubble-commander

### DIFF
--- a/deploy/hubble/templates/ingress.yaml
+++ b/deploy/hubble/templates/ingress.yaml
@@ -9,13 +9,15 @@ metadata:
     traefik.ingress.kubernetes.io/router.entrypoints: websecure
 spec:
   rules:
-    - host: {{ .Values.ingress.host }}
+  {{- range .Values.ingress.hosts }}
+    - host: {{ . }}
       http:
         paths:
           - path: /
             pathType: Prefix
             backend:
               service:
-                name: "{{ include "hubble.fullname" . }}"
+                name: "{{ include "hubble.fullname" $ }}"
                 port:
                   name: http
+  {{- end }}

--- a/deploy/hubble/values.yaml
+++ b/deploy/hubble/values.yaml
@@ -30,7 +30,9 @@ service:
   port: 80
 
 ingress:
-  host: "hubble.crypto.worldcoin.dev"
+  hosts: 
+  - hubble.crypto.worldcoin.dev
+  - production.hubble.worldcoin-distributors.com
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious


### PR DESCRIPTION
This PR adds production.hubble.worldcoin-distributors.com and ability to add multiple hosts within one Ingress manifest