### PR TITLE
temporarily disable lint

### DIFF
--- a/.github/workflows/build-test-deploy.yml
+++ b/.github/workflows/build-test-deploy.yml
@@ -7,18 +7,6 @@ env:
   IMAGE_ID: ghcr.io/${{ github.repository }}:${{ github.sha }}
 
 jobs:
-  lint:
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2
-        with:
-          version: v1.45.2
-          args: --timeout 5m --build-tags hardhat,e2e
-          skip-build-cache: true
-          skip-pkg-cache: true
   test-on-hardhat:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
**problem**: every run of golangci-lint fails [what might be](https://github.com/golangci/golangci-lint/issues/576) an out-of-memory error.

**origin**: as far as I can tell lint broke because of a lack of nix, the last succeeding lint run was [here](https://github.com/worldcoin/hubble-commander/actions/runs/2800118391/jobs/4415003450), it ran lint using go1.18.4. [the next lint run](https://github.com/worldcoin/hubble-commander/actions/runs/2843057705/jobs/4501623310) happened about an hour later and used the same version of golangci-lint, we specify v1.45.2, but it switched to using go1.19, something we did not pin down. Ever since this run golangci-lint has been failing.

**proposed solution**: first merge this PR, then merge all outstanding work, then merge https://github.com/worldcoin/hubble-commander/pull/663 which will fix the root problem by bumping which version of golangci-lint we use

**rejected solution**: merging #663 first will make it difficult to merge the other outstanding PRs because they are fairly big and fragile and rebasing them upon all the lint fixes will add additional effort and might even introduce bugs