### PR TITLE
Fix tests

### DIFF
--- a/commander/disputer/context_test_suite.go
+++ b/commander/disputer/context_test_suite.go
@@ -149,11 +149,8 @@ func (s *testSuiteWithContexts) submitBatch(tx models.GenericTransaction) *model
 }
 
 func (s *testSuiteWithContexts) addTxs(txs models.GenericTransactionArray) {
-	err := s.disputeCtx.storage.BatchAddTransaction(txs)
-	s.NoError(err)
-
 	for i := 0; i < txs.Len(); i++ {
-		err = s.disputeCtx.storage.AddMempoolTx(txs.At(i))
+		err := s.disputeCtx.storage.AddMempoolTx(txs.At(i))
 		s.NoError(err)
 	}
 }

--- a/commander/syncer/sync_test_suite.go
+++ b/commander/syncer/sync_test_suite.go
@@ -162,8 +162,6 @@ func (s *syncTestSuite) createBatch(tx models.GenericTransaction) (*models.Batch
 }
 
 func (s *syncTestSuite) addTx(tx models.GenericTransaction) {
-	err := s.storage.AddTransaction(tx)
-	s.NoError(err)
-	err = s.storage.AddMempoolTx(tx)
+	err := s.storage.AddMempoolTx(tx)
 	s.NoError(err)
 }

--- a/commander/txs_batches_test.go
+++ b/commander/txs_batches_test.go
@@ -557,10 +557,7 @@ func submitInvalidTxsBatch(
 	tx models.GenericTransaction,
 	modifier func(storage *st.Storage, commitment *models.TxCommitmentWithTxs),
 ) *models.Batch {
-	err := storage.AddTransaction(tx)
-	s.NoError(err)
-
-	err = storage.AddMempoolTx(tx)
+	err := storage.AddMempoolTx(tx)
 	s.NoError(err)
 
 	pendingBatch, err := txsCtx.NewPendingBatch(txsCtx.BatchType)

--- a/db/test_db_test.go
+++ b/db/test_db_test.go
@@ -43,7 +43,7 @@ func TestTestDB_Prune(t *testing.T) {
 
 	var res someStruct
 	err = bdg.DB.Get(testStruct.Name, &res)
-	require.Equal(t, bh.ErrNotFound, err)
+	require.ErrorIs(t, err, bh.ErrNotFound)
 }
 
 func TestTestDB_Clone(t *testing.T) {

--- a/eth/get_blocks_to_finalise_test.go
+++ b/eth/get_blocks_to_finalise_test.go
@@ -3,6 +3,7 @@ package eth
 import (
 	"testing"
 
+	"github.com/Worldcoin/hubble-commander/config"
 	"github.com/stretchr/testify/require"
 	"github.com/stretchr/testify/suite"
 )
@@ -28,7 +29,9 @@ func (s *GetBlocksToFinaliseTestSuite) TearDownTest() {
 }
 
 func (s *GetBlocksToFinaliseTestSuite) TestGetBlocksToFinalise() {
-	expected := int64(40320)
+	expected := int64(5760)
+	s.Equal(expected, int64(config.DefaultBlocksToFinalise))
+
 	blocksToFinalise, err := s.client.GetBlocksToFinalise()
 	s.NoError(err)
 	s.Equal(expected, *blocksToFinalise)


### PR DESCRIPTION
The github actions do not run our unit tests. I've been making the mistake of relying on github actions to tell me when tests unrelated to my current task fail which means there's been some test drift over time.

Remaining tasks (added to linear: PRO-314)
- [ ] add the unit tests `make test` to our github action
- [ ] commander/mm_batches_test.go
- [ ] commander/new_block_test.go
- [ ] commander/rollup_test.go
- [ ] commander/sync_stake_withdrawals_test.go
- [ ] commander/txs_batches_test.go
- [ ] commander/disputer/dispute_c2t_signature_test.go
