### PR TITLE
materialize pending pubkey balance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ start-geth-locally:
 
 setup-geth:
 	rm -rf e2e/geth-data/geth
-	docker-compose up -d geth
+	docker compose up -d geth
 	./e2e/geth-data/fundSecondAccount.sh docker
 
 update-contracts:

--- a/api/get_user_states.go
+++ b/api/get_user_states.go
@@ -65,20 +65,19 @@ func (a *API) unsafeGetUserStates(ctx context.Context, publicKey *models.PublicK
 			userStates = append(userStates, dto.MakeUserStateWithID(stateID, pendingState))
 		}
 
-		pendingUserStates, err := func() ([]models.UserState, error) {
+		pendingC2TState, err := func() (*models.UserState, error) {
 			_, innerSpan := getUserStatesTracer.Start(txCtx, "GetPendingC2TState")
 			defer innerSpan.End()
 
-			return txStorage.GetPendingUserStates(publicKey)
+			return txStorage.GetPendingC2TState(publicKey)
 		}()
 		if err != nil {
 			return err
 		}
-		for i := range pendingUserStates {
-			// TODO: change the dto format
+		if pendingC2TState != nil {
 			userStates = append(
 				userStates,
-				dto.MakeUserStateWithID(consts.PendingID, &pendingUserStates[i]),
+				dto.MakeUserStateWithID(consts.PendingID, pendingC2TState),
 			)
 		}
 

--- a/commander/commander.go
+++ b/commander/commander.go
@@ -97,6 +97,11 @@ func (c *Commander) Start() (err error) {
 		return err
 	}
 
+	err = c.storage.MigratePubKeyPendingState()
+	if err != nil {
+		return err
+	}
+
 	c.client, err = getClient(c.blockchain, c.storage, c.cfg, c.metrics, c.txsTrackingChannels)
 	if err != nil {
 		return err

--- a/storage/mempool.go
+++ b/storage/mempool.go
@@ -201,7 +201,11 @@ func (s *Storage) getPendingPubkeyBalance(pubkey *models.PublicKey) (*models.Uin
 
 func (s *Storage) addToPendingPubkeyBalance(pubkey *models.PublicKey, amount *models.Uint256) error {
 	balance, err := s.getPendingPubkeyBalance(pubkey)
-	if err != nil {
+
+	if err != nil && errors.Is(err, badger.ErrKeyNotFound) {
+		addressableValue := models.MakeUint256(0)
+		balance = &addressableValue
+	} else if err != nil {
 		return err
 	}
 

--- a/storage/mempool.go
+++ b/storage/mempool.go
@@ -66,7 +66,7 @@ func pendingStateKey(stateID uint32) []byte {
 
 func pendingPubkeyBalanceKey(pubkey *models.PublicKey) []byte {
 	return bytes.Join(
-		[][]byte{pendingStatePrefix, pubkey[:]},
+		[][]byte{pendingPubkeyBalancePrefix, pubkey[:]},
 		[]byte(":"),
 	)
 }
@@ -287,7 +287,10 @@ func (s *Storage) MigratePubKeyPendingState() error {
 	}
 
 	for pubKey, balance := range keyBalances {
-		s.setPendingPubkeyBalance(&pubKey, balance)
+		err = s.setPendingPubkeyBalance(&pubKey, balance)
+		if err != nil {
+			return err
+		}
 	}
 
 	return s.markRanPubKeyMigration()


### PR DESCRIPTION
`hubble_getUserStates` is extremely slow and prone to latency spikes because it scans the entire mempool looking for the single transaction which sent a c2t to this pubkey. This PR builds a materialized view and will make these calls much cheaper.

Remaining work:
- [x] this slightly changes behavior: previously each c2t sent to a key would show up in `hubble_getUserStates` as a separate `UserState`. Now all pending `c2t`s will be merged into a single `UserState`. This seems unlikely to break clients but we should double check with them
- [x] there is no test for the new behavior that incoming transactions will update the materialized view
- [x] currently this PR breaks the e2e tests
- [x] the migration should be wrapped in a transaction

Future work (must happen before we disable Safe Mode):
- [ ] we need to flush the entry for a public key when a build a batch using the relevant c2t