### PR TITLE
add admin endpoints to debug pending pubkey inconsistencies

### DIFF
--- a/api/admin/mempool.go
+++ b/api/admin/mempool.go
@@ -23,3 +23,23 @@ func (a *API) GetPendingStates(ctx context.Context, startStateID, pageSize uint3
 
 	return a.storage.GetPendingStates(startStateID, pageSize)
 }
+
+// reads the pending balances from badger
+func (a *API) GetPendingPubkeyBalances(ctx context.Context, startPrefix []byte, pageSize uint32) ([]dto.PubkeyBalance, error) {
+	err := a.verifyAuthKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.storage.GetPendingPubkeyBalances(startPrefix, pageSize)
+}
+
+// scans the mempool to recompute the pending balances
+func (a *API) RecomputePubkeyBalances(ctx context.Context, startPrefix []byte, pageSize uint32) ([]dto.PubkeyBalance, error) {
+	err := a.verifyAuthKey(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	return a.storage.RecomputePendingPubkeyBalances(startPrefix, pageSize)
+}

--- a/api/get_user_states.go
+++ b/api/get_user_states.go
@@ -94,5 +94,12 @@ func (a *API) unsafeGetUserStates(ctx context.Context, publicKey *models.PublicK
 		)
 	}
 
+	totalBalance := models.NewUint256(0)
+	for _, userState := range userStates {
+		totalBalance = totalBalance.Add(&userState.Balance)
+	}
+	span.SetAttributes(attribute.String("hubble.response.totalBalance", totalBalance.String()))
+	span.SetAttributes(attribute.Int("hubble.response.userStatesCount", len(userStates)))
+
 	return userStates, nil
 }

--- a/models/dto/user_state.go
+++ b/models/dto/user_state.go
@@ -16,6 +16,11 @@ type UserStateWithID struct {
 	UserState
 }
 
+type PubkeyBalance struct {
+	PubKey  models.PublicKey
+	Balance models.Uint256
+}
+
 func MakeUserStateWithID(stateID uint32, userState *models.UserState) UserStateWithID {
 	return UserStateWithID{
 		StateID:   stateID,

--- a/models/public_key.go
+++ b/models/public_key.go
@@ -35,6 +35,7 @@ func (p PublicKey) Bytes() []byte {
 
 func (p *PublicKey) SetBytes(b []byte) error {
 	if len(b) != PublicKeyLength {
+		// TODO: wrap with stacktrace
 		return ErrInvalidPublicKeyLength
 	}
 

--- a/storage/mempool_test.go
+++ b/storage/mempool_test.go
@@ -143,8 +143,7 @@ func (s *MempoolTestSuite) randomPublicKey() *models.PublicKey {
 // skips all pending state maintenance
 func (s *MempoolTestSuite) rawInsert(tx models.GenericTransaction) {
 	pendingTx := stored.NewPendingTx(tx)
-	txKey := pendingTxKey(pendingTx.FromStateID, pendingTx.Nonce.Uint64())
-	err := s.storage.rawSet(txKey, pendingTx.Bytes())
+	err := s.storage.UnsafeInsertPendingTxSkipValidation(pendingTx)
 	s.NoError(err)
 }
 


### PR DESCRIPTION
users are reporting some claims transactions are not appearing in their wallet balances, these two additional `admin_*` methods will allow me to figure out which users are experiencing problems